### PR TITLE
Add text field component for num of vacancies

### DIFF
--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -2,36 +2,51 @@
   <div class="govuk-form-group">
     <label
       :for="id"
-      class="govuk-heading-m" >
-      {{label}}
+      class="govuk-heading-m"
+    >
+      {{ label }}
     </label>
     <span 
       v-if="hint"
       id="event-name-hint" 
-      class="govuk-hint">
-      {{hint}}
+      class="govuk-hint"
+    >
+      {{ hint }}
     </span>
     <input 
-      :class="[ narrow ? 'govuk-input--width-5 govuk-input' : 'govuk-input' ]"
-      id="key" 
+      id="key"
+      v-model="textFieldValue" 
+      :class="[ (type === 'narrow') ? 'govuk-input--width-5 govuk-input' : 'govuk-input' ]" 
       name="key" 
-      type="text" 
-      v-model="textFieldValue">
+      type="text"
+    >
   </div>
 </template>
 
 <script>
-  export default {
-    data() {
-      return {
-        textFieldValue: ''
-      };
+export default {
+  props: {
+    label: {
+      default: '',
+      type: String,
     },
-    props: {
-      label: String,
-      hint: String,
-      id: String,
-      narrow: Boolean
-    }
-  }
+    hint: {
+      default: '',
+      type: String,
+    },
+    id: {
+      default: '',
+      type: String,
+    },
+    type: {
+      default: '',
+      type: String,
+    },
+  },
+  data() {
+    return {
+      textFieldValue: '',
+    };
+  },
+};
 </script>

--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="govuk-form-group">
+    <label
+      :for="id"
+      class="govuk-heading-m" >
+      {{label}}
+    </label>
+    <span 
+      v-if="hint"
+      id="event-name-hint" 
+      class="govuk-hint">
+      {{hint}}
+    </span>
+    <input 
+      :class="[ narrow ? 'govuk-input--width-5 govuk-input' : 'govuk-input' ]"
+      id="key" 
+      name="key" 
+      type="text" 
+      v-model="textFieldValue">
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        textFieldValue: ''
+      };
+    },
+    props: {
+      label: String,
+      hint: String,
+      id: String,
+      narrow: Boolean
+    }
+  }
+</script>

--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -8,16 +8,15 @@
     </label>
     <span 
       v-if="hint"
-      id="event-name-hint" 
       class="govuk-hint"
     >
       {{ hint }}
     </span>
     <input 
-      id="key"
+      :id="id"
       v-model="textFieldValue" 
       :class="[ (type === 'narrow') ? 'govuk-input--width-5 govuk-input' : 'govuk-input' ]" 
-      name="key" 
+      :name="id" 
       type="text"
     >
   </div>

--- a/src/components/NewExercise/InformationAboutRole.vue
+++ b/src/components/NewExercise/InformationAboutRole.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <h3 class="govuk-heading-xl">
+      About the role
+    </h3>
+    <h2 class="govuk-heading-m">
+      Number of vacancies
+    </h2>
+    <TextField 
+      id="immediate_start" 
+      label="Immediate start" 
+      hint="These are also called section 87 (S87) vacancies"
+      type="narrow"
+    />
+    <TextField 
+      id="future__start" 
+      label="Future start" 
+      hint="These are also called section 94 (S94) vacancies"
+      type="narrow"
+    />
+    <button
+      type="submit"
+      class="govuk-button"
+      data-module="govuk-button"
+    >
+      Continue
+    </button>
+  </div>
+</template>
+
+<script>
+import TextField from '@/components/Form/TextField';
+export default {
+  components: {
+    TextField,
+  },
+};
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ import store from '@/store';
 import Dashboard from '@/views/Dashboard';
 import SignIn from '@/views/SignIn';
 import CreateExercise from '@/views/CreateExercise';
+import InformationAboutRole from '@/components/NewExercise/InformationAboutRole';
 
 Vue.use(Router);
 
@@ -33,6 +34,15 @@ const router = new Router({
       meta: {
         requiresAuth: true,
         title: 'Create new exercise',
+      },
+    },
+    {
+      path: '/exercise/new/information-about-role',
+      name: 'informationAboutRole',
+      component: InformationAboutRole,
+      meta: {
+        requiresAuth: true,
+        title: 'Information about the role',
       },
     },
     {

--- a/tests/unit/components/Form/TextField.spec.js
+++ b/tests/unit/components/Form/TextField.spec.js
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils';
+import TextField from '@/components/Form/TextField';
+
+describe('components/Form/TextField', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(TextField);
+  });
+
+  it('renders the component', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe("TextField props", () => {
+
+    describe("label", () => {
+      it("sets the label", () => {
+        wrapper.setProps({ label: 'My Form Label' });
+        expect(wrapper.find('label').text()).toBe('My Form Label');
+      });
+    })
+
+    describe("hint", () => {
+      it("shows hint element if hint is true", () => {
+        wrapper.setProps({ hint: 'my_hint' });
+        expect(wrapper.find('.govuk-hint').exists()).toBe(true)
+      }) 
+
+      it("sets hint element content", () => {
+        wrapper.setProps({ hint: 'Hint for the label!' });
+         expect(wrapper.find('.govuk-hint').text()).toBe('Hint for the label!');
+      }) 
+
+      it("does not show hint if hint is not passed", () => {
+        expect(wrapper.find('.govuk-hint').exists()).toBe(false)
+      }) 
+    });
+
+    describe("id", () => {
+      it("sets the label for attribute", () => {
+        wrapper.setProps({ id: 'my_unique_key' });
+        expect(wrapper.find('label').attributes().for).toBe('my_unique_key')
+      }) 
+    });
+
+    describe("narrow", () => {
+      it("sets CSS class is narrow is true", () => {
+        wrapper.setProps({ narrow: true });
+        expect(wrapper.find('input').attributes().class).toContain('govuk-input--width-5')
+      });
+
+      it("doesn't set CSS class is narrow is not passed", () => {
+        wrapper.setProps({});
+        expect(wrapper.find('input').attributes().class).not.toContain('govuk-input--width-5')
+      })
+    })
+  })
+});

--- a/tests/unit/components/Form/TextField.spec.js
+++ b/tests/unit/components/Form/TextField.spec.js
@@ -38,19 +38,24 @@ describe('components/Form/TextField', () => {
     });
 
     describe('id', () => {
-      it('sets the label for attribute', () => {
+      it('sets label for attribute', () => {
         wrapper.setProps({ id: 'my_unique_key' });
         expect(wrapper.find('label').attributes().for).toBe('my_unique_key');
+      }); 
+
+      it('sets id for input', () => {
+        wrapper.setProps({ id: 'my_unique_key' });
+        expect(wrapper.find('input').attributes().id).toBe('my_unique_key');
       }); 
     });
 
     describe('type', () => {
-      it('sets CSS class is narrow is true', () => {
+      it('sets CSS class if type is narrow', () => {
         wrapper.setProps({ type: 'narrow' });
         expect(wrapper.find('input').attributes().class).toContain('govuk-input--width-5');
       });
 
-      it("doesn't set CSS class is narrow is not passed", () => {
+      it("does not set CSS class if type is not passed", () => {
         wrapper.setProps({});
         expect(wrapper.find('input').attributes().class).not.toContain('govuk-input--width-5');
       });

--- a/tests/unit/components/Form/TextField.spec.js
+++ b/tests/unit/components/Form/TextField.spec.js
@@ -12,48 +12,48 @@ describe('components/Form/TextField', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  describe("TextField props", () => {
+  describe('TextField props', () => {
 
-    describe("label", () => {
-      it("sets the label", () => {
+    describe('label', () => {
+      it('sets the label', () => {
         wrapper.setProps({ label: 'My Form Label' });
         expect(wrapper.find('label').text()).toBe('My Form Label');
       });
-    })
+    });
 
-    describe("hint", () => {
-      it("shows hint element if hint is true", () => {
+    describe('hint', () => {
+      it('shows hint element if hint is true', () => {
         wrapper.setProps({ hint: 'my_hint' });
-        expect(wrapper.find('.govuk-hint').exists()).toBe(true)
-      }) 
+        expect(wrapper.find('.govuk-hint').exists()).toBe(true);
+      }); 
 
-      it("sets hint element content", () => {
+      it('sets hint element content', () => {
         wrapper.setProps({ hint: 'Hint for the label!' });
          expect(wrapper.find('.govuk-hint').text()).toBe('Hint for the label!');
-      }) 
+      }); 
 
-      it("does not show hint if hint is not passed", () => {
-        expect(wrapper.find('.govuk-hint').exists()).toBe(false)
-      }) 
+      it('does not show hint if hint is not passed', () => {
+        expect(wrapper.find('.govuk-hint').exists()).toBe(false);
+      }); 
     });
 
-    describe("id", () => {
-      it("sets the label for attribute", () => {
+    describe('id', () => {
+      it('sets the label for attribute', () => {
         wrapper.setProps({ id: 'my_unique_key' });
-        expect(wrapper.find('label').attributes().for).toBe('my_unique_key')
-      }) 
+        expect(wrapper.find('label').attributes().for).toBe('my_unique_key');
+      }); 
     });
 
-    describe("narrow", () => {
-      it("sets CSS class is narrow is true", () => {
-        wrapper.setProps({ narrow: true });
-        expect(wrapper.find('input').attributes().class).toContain('govuk-input--width-5')
+    describe('type', () => {
+      it('sets CSS class is narrow is true', () => {
+        wrapper.setProps({ type: 'narrow' });
+        expect(wrapper.find('input').attributes().class).toContain('govuk-input--width-5');
       });
 
       it("doesn't set CSS class is narrow is not passed", () => {
         wrapper.setProps({});
-        expect(wrapper.find('input').attributes().class).not.toContain('govuk-input--width-5')
-      })
-    })
-  })
+        expect(wrapper.find('input').attributes().class).not.toContain('govuk-input--width-5');
+      });
+    });
+  });
 });

--- a/tests/unit/components/Form/TextField.spec.js
+++ b/tests/unit/components/Form/TextField.spec.js
@@ -55,7 +55,7 @@ describe('components/Form/TextField', () => {
         expect(wrapper.find('input').attributes().class).toContain('govuk-input--width-5');
       });
 
-      it("does not set CSS class if type is not passed", () => {
+      it('does not set CSS class if type is not passed', () => {
         wrapper.setProps({});
         expect(wrapper.find('input').attributes().class).not.toContain('govuk-input--width-5');
       });

--- a/tests/unit/components/NewExercise/InformationAboutRole.spec.js
+++ b/tests/unit/components/NewExercise/InformationAboutRole.spec.js
@@ -1,0 +1,21 @@
+import { shallowMount } from '@vue/test-utils';
+import InformationAboutRole from '@/components/NewExercise/InformationAboutRole';
+import TextField from '@/components/Form/TextField';
+
+describe('components/NewExercise/InformationAboutRole', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(InformationAboutRole);
+  });
+
+  it('renders the component', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe('child components', () => {
+    it('renders TextField component', () => {
+      expect(wrapper.find(TextField).exists()).toBe(true);
+    });
+  });
+});

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -77,4 +77,21 @@ describe('Page titles', () => {
       expect(document.title).toContain('Judicial Appointments Commission');
     });
   });
+
+  describe('Information About Role Page', () => {
+
+    beforeEach(() => {
+      store.dispatch('setCurrentUser', user);
+    });
+
+    it('sets title as Information about the role', () => {
+      router.push('/exercise/new/information-about-role');
+      expect(document.title).toContain('Information about the role');
+    });
+
+    it('contains Judicial Appointments Commission', () => {
+      router.push('/exercise/new');
+      expect(document.title).toContain('Judicial Appointments Commission');
+    });
+  });
 });


### PR DESCRIPTION
**Change log:**
1) Add component TextField
2) Create a new view for an "About the role" form
3) Use new TextField component to display Immediate start and Future start fields.

! to get to this component, go to http://localhost:8080/exercise/new/information-about-role.
As this journey should start on a View Vanancy page and View Vanancy page doesn't exist yet, we display form in a separate view which will be connected to View Vanancy page in the future.
