### PR TITLE
Add type option to DateInput

### DIFF
--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -24,7 +24,8 @@
       >
         <div 
           v-if="type === 'date'"
-          class="govuk-date-input__item">
+          class="govuk-date-input__item"
+        >
           <div class="govuk-form-group">
             <label
               class="govuk-label govuk-date-input__label"

--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -22,7 +22,9 @@
         :id="id"
         class="govuk-date-input"
       >
-        <div class="govuk-date-input__item">
+        <div 
+          v-if="type === 'date'"
+          class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label
               class="govuk-label govuk-date-input__label"
@@ -97,6 +99,10 @@ export default {
       required: true,
       type: String,
     },
+    type: {
+      default: 'date',
+      validator: (value) => (['date', 'month'].indexOf(value) !== -1),
+    },
     value: {
       required: true,
       validator: (value) => (value instanceof Date || value === null || value === undefined),
@@ -135,7 +141,7 @@ export default {
       },
     },
     dateConstructor() {
-      const day = this.day;
+      const day = this.type === 'month' ? 1 : this.day;
       const month = this.month;
       const year = this.year;
 

--- a/tests/unit/components/Form/DateInput.spec.js
+++ b/tests/unit/components/Form/DateInput.spec.js
@@ -300,21 +300,21 @@ describe('components/DateInput', () => {
 
       describe('given property type="month"', () => {
         beforeEach(() => {
-          subject.setProps({type: 'month'});
+          subject.setProps({ type: 'month' });
         });
 
         describe('and `month` and `year` fields are set', () => {
           it('returns an array of Date constructor arguments', () => {
-            subject.setData({month: 4, year: 1980});
+            subject.setData({ month: 4, year: 1980 });
             expect(subject.vm.dateConstructor).toHaveLength(3);
             expect(subject.vm.dateConstructor).toEqual([1980, 3, 1]);
           });
 
           it('adjusts month to be zero-indexed, as required by Date constructor', () => {
-            subject.setData({month: 1, year: 1960});
+            subject.setData({ month: 1, year: 1960 });
             expect(subject.vm.dateConstructor).toEqual([1960, 0, 1]);
 
-            subject.setData({month: 12, year: 1960});
+            subject.setData({ month: 12, year: 1960 });
             expect(subject.vm.dateConstructor).toEqual([1960, 11, 1]);
           });
         });
@@ -495,7 +495,7 @@ describe('components/DateInput', () => {
 
     describe('given property type="month"', () => {
       beforeEach(() => {
-        subject.setProps({type: 'month'});
+        subject.setProps({ type: 'month' });
       });
 
       describe('Day input', () => {


### PR DESCRIPTION
As in some cases we want to display only month and a year inputs, we've added type "month" which will hide a day input field and will return a date object with the default value 1 for a day.

**Change log**
1) Add new optional prop "type" to DateInput, which will accept "month" if we only want to see the month and a year
2) Update DateConstructor property which in case if the type is "month" uses default value 1 for a day.
3) Update tests