### PR TITLE
Refactored TextField component `type` prop

### DIFF
--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -17,7 +17,7 @@
       v-model="text"
       :class="inputClass + ' govuk-input'"
       :name="id"
-      type="tel"
+      :type="type"
     >
   </div>
 </template>
@@ -43,6 +43,10 @@ export default {
     },
     id: {
       default: '',
+      type: String,
+    },
+    type: {
+      default: 'text',
       type: String,
     },
   },

--- a/tests/unit/components/Form/TextField.spec.js
+++ b/tests/unit/components/Form/TextField.spec.js
@@ -84,6 +84,21 @@ describe('components/Form/TextField', () => {
         });
       });
     });
+
+    describe('type', () => {
+      describe('when the prop is set', () => {
+        it('includes the added value in the <input> `type` attribute', () => {
+          wrapper.setProps({ type: 'my_type' });
+          expect(wrapper.find('input').attributes('type')).toBe('my_type');
+        });
+      });
+
+      describe('when the prop is not set', () => {
+        it('has the default <input> `type` text', () => {
+          expect(wrapper.find('input').attributes('type')).toBe('text');
+        });
+      });
+    });
   });
 
   describe('`v-model` interface', () => {


### PR DESCRIPTION
- We have changed the type of the text field component to take a default 
type of 'text', however it can receive a new one from the parent.
- We have also added tests to account for this new change. 