### PR TITLE
Scaffold Add Exercise Contacts

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ import store from '@/store';
 import AboutTheRole from '@/views/AboutTheRole';
 import AboutTheSelectionProcess from '@/views/AboutTheSelectionProcess';
 import CreateAnExercise from '@/views/CreateAnExercise';
+import AddExerciseContacts from '@/views/AddExerciseContacts';
 import Dashboard from '@/views/Dashboard';
 import Eligibility from '@/views/Eligibility';
 import SignIn from '@/views/SignIn';
@@ -64,6 +65,15 @@ const router = new Router({
           meta: {
             requiresAuth: true,
             title: 'Create An Exercise',
+          },
+        },
+        {
+          path: 'add-exercise-contacts',
+          component: AddExerciseContacts,
+          name: 'add-exercise-contacts',
+          meta: {
+            requiresAuth: true,
+            title: 'Add Exercise Contacts',
           },
         },
         {

--- a/src/views/AddExerciseContacts.vue
+++ b/src/views/AddExerciseContacts.vue
@@ -1,0 +1,79 @@
+<template>
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          Add exercise contacts
+        </h1>
+        <p class="govuk-body-l">You can return to this page later
+            to add or change contacts.
+        </p>
+        <h2 class="govuk-heading-l">
+            JAC contacts
+        </h2>
+        <TextField
+          id="policy-contact"
+          v-model="policyContact"
+          name="policy-contact"
+          label="Policy contact"
+        />
+        <TextField
+          id="equality-diversity-contact"
+          v-model="equalityDiversityContact"
+          name="equality-diversity-contact"
+          label="Equality and diversity contact"
+        />
+        <TextField
+          id="senior-selection-exercise-manager"
+          v-model="seniorSelectionExerciseManager"
+          name="senior-selection-exercise-manager"
+          label="Senior selection exercise manager"
+        />
+        <TextField
+          id="selection-exercise-manager"
+          v-model="selectionExerciseManager"
+          name="selection-exercise-manager"
+          label="Selection exercise manager"
+        />
+        <TextField
+          id="selection-exercise-officer"
+          v-model="selectionExerciseOfficer"
+          name="selection-exercise-officer"
+          label="Selection exercise officer"
+        />
+        <p class="govuk_body">
+          <a href="#">Add another</a>
+        </p>
+
+        <TextField
+          id="assigned-commissioner"
+          v-model="assignedCommissioner"
+          name="assigned-commissioner"
+          label="Assigned commissioner"
+        />
+        <p class="govuk_body">
+          <a href="#">Add another</a>
+        </p>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script>
+  import TextField from '@/components/Form/TextField';
+  export default {
+    components: {
+      TextField,
+    },
+    data(){
+      return {
+        policyContact: null,
+        equalityDiversityContact: null,
+        seniorSelectionExerciseManager: null,
+        selectionExerciseManager: null,
+        selectionExerciseOfficer: null,
+        assignedCommissioner: null,
+      };
+    },
+}
+</script>

--- a/src/views/AddExerciseContacts.vue
+++ b/src/views/AddExerciseContacts.vue
@@ -2,45 +2,54 @@
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+
         <h1 class="govuk-heading-xl">
           Add exercise contacts
         </h1>
-        <p class="govuk-body-l">You can return to this page later
-            to add or change contacts.
+
+        <p class="govuk-body-l">
+          You can return to this page later to add or change contacts.
         </p>
+
         <h2 class="govuk-heading-l">
-            JAC contacts
+          JAC contacts
         </h2>
+
         <TextField
           id="policy-contact"
           v-model="policyContact"
           name="policy-contact"
           label="Policy contact"
         />
+
         <TextField
           id="equality-diversity-contact"
           v-model="equalityDiversityContact"
           name="equality-diversity-contact"
           label="Equality and diversity contact"
         />
+
         <TextField
           id="senior-selection-exercise-manager"
           v-model="seniorSelectionExerciseManager"
           name="senior-selection-exercise-manager"
           label="Senior selection exercise manager"
         />
+
         <TextField
           id="selection-exercise-manager"
           v-model="selectionExerciseManager"
           name="selection-exercise-manager"
           label="Selection exercise manager"
         />
+
         <TextField
           id="selection-exercise-officer"
           v-model="selectionExerciseOfficer"
           name="selection-exercise-officer"
           label="Selection exercise officer"
         />
+
         <p class="govuk_body">
           <a href="#">Add another</a>
         </p>
@@ -51,9 +60,84 @@
           name="assigned-commissioner"
           label="Assigned commissioner"
         />
+
         <p class="govuk_body">
           <a href="#">Add another</a>
         </p>
+
+        <h2 class="govuk-heading-l">
+          Other contacts
+        </h2>
+
+        <CheckboxGroup
+          id="appropriate-authority"
+          v-model="appropriateAuthority"
+          label="Appropriate authority"
+          hint="Select all that apply."
+        >
+          <CheckboxItem
+            value="lord-chancellor"
+            label="Lord Chancellor"
+          />
+          <CheckboxItem
+            value="lord-chief-justice"
+            label="Lord Chief Justice"
+          />
+          <CheckboxItem
+            value="senior-president-tribunals"
+            label="Senior President of Tribunals"
+          />
+        </CheckboxGroup>
+
+        <TextField
+          id="judicial-office-contact"
+          v-model="judicialOfficeContact"
+          name="judicial-office-contact"
+          label="Judicial Office contact"
+        />
+
+        <TextField
+          id="hmcts-welshgov-lead"
+          v-model="hmctsWelshGovLead"
+          name="hmcts-welshgov-lead"
+          label="HMCTS or Welsh Government lead"
+        />
+
+        <TextField
+          id="lead-judge"
+          v-model="leadJudge"
+          name="lead-judge"
+          label="Lead judge"
+        />
+
+        <TextField
+          id="drafting-judge"
+          v-model="draftingJudge"
+          name="drafting-judge"
+          label="Drafting judge"
+        />
+
+        <p class="govuk_body">
+          <a href="#">Add another</a>
+        </p>
+
+        <TextField
+          id="statutory-consultee"
+          v-model="statutoryConsultee"
+          name="statutory-consultee"
+          label="Statutory consultee"
+        />
+
+        <p class="govuk_body">
+          <a href="#">Add another</a>
+        </p>
+
+        <button
+          class="govuk-button"
+        >
+          Save and continue
+        </button>
+
       </div>
     </div>
   </main>
@@ -61,9 +145,14 @@
 
 <script>
   import TextField from '@/components/Form/TextField';
+  import CheckboxGroup from '@/components/Form/CheckboxGroup';
+  import CheckboxItem from '@/components/Form/CheckboxItem';
+
   export default {
     components: {
       TextField,
+      CheckboxGroup,
+      CheckboxItem,
     },
     data(){
       return {
@@ -73,6 +162,12 @@
         selectionExerciseManager: null,
         selectionExerciseOfficer: null,
         assignedCommissioner: null,
+        appropriateAuthority: [],
+        judicialOfficeContact: null,
+        hmctsWelshGovLead: null,
+        leadJudge: null,
+        draftingJudge: null,
+        statutoryConsultee: null,
       };
     },
 }

--- a/src/views/AddExerciseContacts.vue
+++ b/src/views/AddExerciseContacts.vue
@@ -2,7 +2,6 @@
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
         <h1 class="govuk-heading-xl">
           Add exercise contacts
         </h1>
@@ -51,7 +50,10 @@
         />
 
         <p class="govuk_body">
-          <a href="#">Add another</a>
+          <a
+            href="#"
+            class="govuk-link"
+          >Add another</a>
         </p>
 
         <TextField
@@ -62,7 +64,10 @@
         />
 
         <p class="govuk_body">
-          <a href="#">Add another</a>
+          <a
+            href="#"
+            class="govuk-link"
+          >Add another</a>
         </p>
 
         <h2 class="govuk-heading-l">
@@ -118,7 +123,10 @@
         />
 
         <p class="govuk_body">
-          <a href="#">Add another</a>
+          <a
+            href="#"
+            class="govuk-link"
+          >Add another</a>
         </p>
 
         <TextField
@@ -129,7 +137,10 @@
         />
 
         <p class="govuk_body">
-          <a href="#">Add another</a>
+          <a
+            href="#"
+            class="govuk-link"
+          >Add another</a>
         </p>
 
         <button
@@ -137,38 +148,37 @@
         >
           Save and continue
         </button>
-
       </div>
     </div>
   </main>
 </template>
 
 <script>
-  import TextField from '@/components/Form/TextField';
-  import CheckboxGroup from '@/components/Form/CheckboxGroup';
-  import CheckboxItem from '@/components/Form/CheckboxItem';
+import TextField from '@/components/Form/TextField';
+import CheckboxGroup from '@/components/Form/CheckboxGroup';
+import CheckboxItem from '@/components/Form/CheckboxItem';
 
-  export default {
-    components: {
-      TextField,
-      CheckboxGroup,
-      CheckboxItem,
-    },
-    data(){
-      return {
-        policyContact: null,
-        equalityDiversityContact: null,
-        seniorSelectionExerciseManager: null,
-        selectionExerciseManager: null,
-        selectionExerciseOfficer: null,
-        assignedCommissioner: null,
-        appropriateAuthority: [],
-        judicialOfficeContact: null,
-        hmctsWelshGovLead: null,
-        leadJudge: null,
-        draftingJudge: null,
-        statutoryConsultee: null,
-      };
-    },
-}
+export default {
+  components: {
+    TextField,
+    CheckboxGroup,
+    CheckboxItem,
+  },
+  data(){
+    return {
+      policyContact: null,
+      equalityDiversityContact: null,
+      seniorSelectionExerciseManager: null,
+      selectionExerciseManager: null,
+      selectionExerciseOfficer: null,
+      assignedCommissioner: null,
+      appropriateAuthority: [],
+      judicialOfficeContact: null,
+      hmctsWelshGovLead: null,
+      leadJudge: null,
+      draftingJudge: null,
+      statutoryConsultee: null,
+    };
+  },
+};
 </script>

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -129,6 +129,23 @@ describe('Page titles', () => {
     });
   });
 
+  describe('AddExerciseContacts', () => {
+
+    beforeEach(() => {
+      store.dispatch('setCurrentUser', user);
+    });
+
+    it('sets title as Add Exercise Contacts', () => {
+      router.push('/exercise/new/create-an-exercise');
+      expect(document.title).toContain('Create An Exercise');
+    });
+
+    it('contains Judicial Appointments Commission', () => {
+      router.push('/exercise/new/add-exercise-contacts');
+      expect(document.title).toContain('Judicial Appointments Commission');
+    });
+  });
+
   describe('About The Selection Process', () => {
 
     beforeEach(() => {

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -57,6 +57,13 @@ describe('Sign in journey', () => {
       });
     });
 
+    describe('when they visit /exercise/new/add-exercise-contacts', () => {
+      it('redirects to /sign-in page', () => {
+        router.push('/exercise/new/add-exercise-contacts');
+        expect(subject.vm.$route.path).toBe('/sign-in');
+      });
+    });
+
     describe('when they visit /exercise/new/about-the-selection-process', () => {
       it('redirects to /sign-in page', () => {
         router.push('/exercise/new/about-the-selection-process');
@@ -117,6 +124,13 @@ describe('Sign in journey', () => {
       it('can access the new create an exercise page', () => {
         router.push('/exercise/new/create-an-exercise');
         expect(subject.vm.$route.path).toBe('/exercise/new/create-an-exercise');
+      });
+    });
+
+    describe('when going to the add exercise contacts page', () => {
+      it('can access the new add exercise contacts page', () => {
+        router.push('/exercise/new/add-exercise-contacts');
+        expect(subject.vm.$route.path).toBe('/exercise/new/add-exercise-contacts');
       });
     });
 

--- a/tests/unit/views/AddExerciseContacts.spec.js
+++ b/tests/unit/views/AddExerciseContacts.spec.js
@@ -1,0 +1,26 @@
+import AddExerciseContacts from '@/views/AddExerciseContacts';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Router from 'vue-router';
+
+const localVue = createLocalVue();
+localVue.use(Router);
+
+describe('AddExerciseContacts', () => {
+  it('renders the view', () => {
+    let wrapper = shallowMount(AddExerciseContacts, {
+      localVue,
+    });
+
+    expect(wrapper.exists()).toBe(true);
+  });
+});
+
+describe('Accessibility:', () => {
+  it('page contains h1 element', () => {
+    let wrapper = shallowMount(AddExerciseContacts, {
+      localVue,
+    });
+
+    expect(wrapper.contains('h1')).toBe(true);
+  });
+});


### PR DESCRIPTION
- Created a scaffold page using our new components, and the new prototype as a guideline. 
- Added a path to our router for this page. 
- Created tests in the View, and Journey folders. 

- Need to link up the 'Save and continue' button on the CreateAnExercise page to point to the AddExerciseContacts page. 
- Need to link up the 'Save and continue' button on the AddExerciseContacts page to point to the next page. 
- Need to make the 'add another' links operational (they currently do nothing).