### PR TITLE
Add repeatableTextFields

### DIFF
--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="repeatableContainer">
     <div
       v-for="(row, index) in rows"
       :key="index"
@@ -108,4 +108,15 @@ export default {
   .repeatableField .govuk-form-group {
     margin-bottom: 1em;
   }
+
+  .repeatableContainer .repeatableField:not(:first-child) label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+  } 
 </style>

--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="repeatableContainer">
+  <div>
     <div
       v-for="(row, index) in rows"
       :key="index"
@@ -108,15 +108,4 @@ export default {
   .repeatableField .govuk-form-group {
     margin-bottom: 1em;
   }
-
-  .repeatableContainer .repeatableField:not(:first-child) label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    border: 0;
-  } 
 </style>

--- a/src/components/RepeatableFields/DraftingJudge.vue
+++ b/src/components/RepeatableFields/DraftingJudge.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <TextField 
+      :id="`drafting_judge_${index}`"
+      v-model="row.name"
+      type="text"
+      label="Drafting judge"
+    />
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import TextField from '@/components/Form/TextField';
+
+export default {
+  components: {
+    TextField,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+  },
+};
+</script>

--- a/src/components/RepeatableFields/StatutoryConsultee.vue
+++ b/src/components/RepeatableFields/StatutoryConsultee.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <TextField 
+      :id="`statutory_consultee_${index}`"
+      v-model="row.name"
+      type="text"
+      label="Statutory Consultee"
+    />
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import TextField from '@/components/Form/TextField';
+
+export default {
+  components: {
+    TextField,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+  },
+};
+</script>

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -127,29 +127,16 @@
         label="Lead judge"
       />
 
-      <TextField
-        id="drafting-judge"
+      <RepeatableFields
         v-model="draftingJudge"
-        name="drafting-judge"
-        label="Drafting judge"
+        :component="repeatableFields.DraftingJudge"
       />
-      <p class="govuk_body">
-        <a
-          class="govuk-link"
-        >Add another</a>
-      </p>
-
-      <TextField
-        id="statutory-consultee"
+    
+      <RepeatableFields
         v-model="statutoryConsultee"
-        label="Statutory consultee"
+        :component="repeatableFields.StatutoryConsultee"
       />
 
-      <p class="govuk_body">
-        <a
-          class="govuk-link"
-        >Add another</a>
-      </p>
 
       <button
         ref="linkToAddShortlistingMethods"
@@ -166,12 +153,16 @@
 import TextField from '@/components/Form/TextField';
 import CheckboxGroup from '@/components/Form/CheckboxGroup';
 import CheckboxItem from '@/components/Form/CheckboxItem';
+import RepeatableFields from '@/components/RepeatableFields';
+import DraftingJudge from '@/components/RepeatableFields/DraftingJudge';
+import StatutoryConsultee from '@/components/RepeatableFields/StatutoryConsultee';
 
 export default {
   components: {
     TextField,
     CheckboxGroup,
     CheckboxItem,
+    RepeatableFields,
   },
   data(){
     return {
@@ -187,6 +178,10 @@ export default {
       leadJudge: null,
       draftingJudge: null,
       statutoryConsultee: null,
+      repeatableFields: {
+        DraftingJudge,
+        StatutoryConsultee,
+      },
     };
   },
 };

--- a/tests/unit/components/RepeatableFields/RepeatableTextFields.spec.js
+++ b/tests/unit/components/RepeatableFields/RepeatableTextFields.spec.js
@@ -11,30 +11,50 @@ const repeatableTextFields = [
   ['StatutoryConsultee', StatutoryConsultee],
 ];
 
-describe('RepeatableTextFields', () => {
-  it.each(repeatableTextFields)('renders TextField component for %s', (label, component) => {
-    const wrapper = shallowMount(component, {
-      propsData: {
-        row: {},
-        index: 1,
-      },
-    });
-    expect(wrapper.find(TextField).exists()).toBe(true);
-  });
-
-  describe('props', () => {
-    it.each(repeatableTextFields)('%s: row is required and has a type object', (label, component) => {
-      let prop = component.props.row;
-    
-      expect(prop.required).toBe(true);
-      expect(prop.type).toBe(Object);
+describe('Repeatable text fields', () => {
+  describe.each(repeatableTextFields)('@/components/RepeatableFields/%s', (label, component) => {
+    it('renders TextField component', () => {
+      const wrapper = shallowMount(component, {
+        propsData: {
+          row: {},
+          index: 1,
+        },
+      });
+      expect(wrapper.find(TextField).exists()).toBe(true);
     });
 
-    it.each(repeatableTextFields)('%s: index is required and has a type number', (label, component) => {
-      let prop = component.props.index;
-    
-      expect(prop.required).toBe(true);
-      expect(prop.type).toBe(Number);
+    describe('props', () => {
+      describe('row', () => {
+        let prop;
+
+        beforeEach(() => {
+          prop = component.props.row;
+        });
+
+        it('is required', () => {
+          expect(prop.required).toBe(true);
+        });
+
+        it('has a type object', () => {
+          expect(prop.type).toBe(Object);
+        });
+      });
+      
+      describe('index', () => {
+        let prop;
+        
+        beforeEach(() => {
+          prop = component.props.index;
+        });
+
+        it('is required', () => {
+          expect(prop.required).toBe(true);
+        });
+
+        it('has a type number', () => {
+          expect(prop.type).toBe(Number);
+        });
+      });
     });
   });
 });

--- a/tests/unit/components/RepeatableFields/RepeatableTextFields.spec.js
+++ b/tests/unit/components/RepeatableFields/RepeatableTextFields.spec.js
@@ -1,0 +1,40 @@
+import TextField from '@/components/Form/TextField';
+import { shallowMount } from '@vue/test-utils';
+
+// repeatable components
+import DraftingJudge from '@/components/RepeatableFields/DraftingJudge';
+import StatutoryConsultee from '@/components/RepeatableFields/StatutoryConsultee';
+
+// add repeatable text component to this array
+const repeatableTextFields = [
+  ['DraftingJudge', DraftingJudge],
+  ['StatutoryConsultee', StatutoryConsultee],
+];
+
+describe('RepeatableTextFields', () => {
+  it.each(repeatableTextFields)('renders TextField component for %s', (label, component) => {
+    const wrapper = shallowMount(component, {
+      propsData: {
+        row: {},
+        index: 1,
+      },
+    });
+    expect(wrapper.find(TextField).exists()).toBe(true);
+  });
+
+  describe('props', () => {
+    it.each(repeatableTextFields)('%s: row is required and has a type object', (label, component) => {
+      let prop = component.props.row;
+    
+      expect(prop.required).toBe(true);
+      expect(prop.type).toBe(Object);
+    });
+
+    it.each(repeatableTextFields)('%s: index is required and has a type number', (label, component) => {
+      let prop = component.props.index;
+    
+      expect(prop.required).toBe(true);
+      expect(prop.type).toBe(Number);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds two repeatable text fields that can be used as an example for all future repeatable text fields.

**Change log**
1) Update style of the repeatable component so only the first label in repeatableContainer is visible
2) Create two repeatable text fields components for a contact page and integrate them into a page
3) Add a test that can be reused for all future repeatable text fields