### PR TITLE
Convert Firestore Timestamp objects to Date objects

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -22,7 +22,6 @@ const firestore = firebase.firestore();
 // Other firebase exports
 const auth = firebase.auth;
 const functions = firebase.functions;
-const Timestamp = firebase.firestore.Timestamp;
 
-export { firestore, auth, functions, Timestamp };
+export { firestore, auth, functions };
 export default firebase;

--- a/src/helpers/convertFirestoreTimestampsToDates.js
+++ b/src/helpers/convertFirestoreTimestampsToDates.js
@@ -1,0 +1,20 @@
+import firebase from '@/firebase';
+const Timestamp = firebase.firestore.Timestamp;
+
+const reviver = (key, value) => {
+  // Convert serialized Timestamp objects to Date objects
+  if (value && typeof value == 'object' && typeof value.seconds == 'number' && typeof value.nanoseconds == 'number') {
+    value = new Timestamp(value.seconds, value.nanoseconds).toDate();
+  }
+  return value;
+};
+
+const convertFirestoreTimestampsToDates = (data) => {
+  // Return non-object values untouched
+  if (typeof data !== 'object' || data === null) return data;
+
+  const json = JSON.stringify(data);
+  return JSON.parse(json, reviver);
+};
+
+export default convertFirestoreTimestampsToDates;

--- a/src/helpers/vuexfireSerialize.js
+++ b/src/helpers/vuexfireSerialize.js
@@ -1,0 +1,24 @@
+import convertFirestoreTimestampsToDates from '@/helpers/convertFirestoreTimestampsToDates';
+
+/**
+ * Vuexfire serialize method
+ *
+ * Provide this function as the value of the `serialize` option on calls to `firestoreAction`
+ * For more information on the `serialize` option, see: https://vuefire.vuejs.org/api/vuefire.html#options-serialize
+ */
+const vuexfireSerialize = (snapshot) => {
+  let data = snapshot.data();
+
+  // Convert Firestore Timestamp objects to regular JavaScript Date objects
+  data = convertFirestoreTimestampsToDates(data);
+
+  // snapshot.data() DOES NOT contain the `id` of the document. By
+  // default, Vuefire adds it as a non enumerable property named id.
+  // This allows to easily create copies when updating documents, as using
+  // the spread operator won't copy it
+  data = Object.defineProperty(data, 'id', { value: snapshot.id });
+
+  return data;
+};
+
+export default vuexfireSerialize;

--- a/src/store/exercise/collection.js
+++ b/src/store/exercise/collection.js
@@ -1,14 +1,14 @@
 import { firestore } from '@/firebase';
 import { firestoreAction } from 'vuexfire';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
 
 export default {
   namespaced: true,
   actions: {
     bind: firestoreAction(({ bindFirestoreRef }) => {
       const firestoreRef = firestore
-        .collection('exercises')
-        .orderBy('openAt', 'desc');
-      return bindFirestoreRef('records', firestoreRef);
+        .collection('exercises');
+      return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('records');

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -1,5 +1,6 @@
 import { firestore } from '@/firebase';
 import { firestoreAction } from 'vuexfire';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
 
 const collection = firestore.collection('exercises');
 
@@ -8,7 +9,7 @@ export default {
   actions: {
     bind: firestoreAction(({ bindFirestoreRef }, id) => {
       const firestoreRef = collection.doc(id);
-      return bindFirestoreRef('record', firestoreRef);
+      return bindFirestoreRef('record', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('record');

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -26,15 +26,15 @@
       <div class="govuk-grid-column-full">
         <dl class="govuk-summary-list govuk-!-margin-bottom-9">
           <div 
-            v-for="vacancy in records"
-            :key="vacancy.reference"
+            v-for="exercise in records"
+            :key="exercise.id"
             class="govuk-summary-list__row"
           >
             <dt class="govuk-summary-list__key">
-              <a href="detail">{{ vacancy.reference }}</a>
+              <a href="detail">{{ exercise.reference }}</a>
             </dt>
             <dd class="govuk-summary-list__value">
-              <a href="detail">{{ vacancy.title }}</a>
+              <a href="detail">{{ exercise.name }}</a>
             </dd>
           </div>
         </dl>

--- a/tests/unit/helpers/convertFirestoreTimestampsToDates.spec.js
+++ b/tests/unit/helpers/convertFirestoreTimestampsToDates.spec.js
@@ -1,0 +1,109 @@
+import convertFirestoreTimestampsToDates from '@/helpers/convertFirestoreTimestampsToDates';
+import firebase from '@/firebase';
+const Timestamp = firebase.firestore.Timestamp;
+
+describe('helpers/convertFirestoreTimestampsToDates', () => {
+  const date = new Date('2015-12-23 22:33:44');
+  const timestamp = Timestamp.fromDate(date);
+
+  it('converts Firestore Timestamp objects into equivalent Date objects', () => {
+    const data = {
+      name: 'John Smith',
+      appliedDate: timestamp,
+      qtPassed: true,
+      qtScore: 28,
+    };
+
+    const converted = convertFirestoreTimestampsToDates(data);
+
+    expect(converted.appliedDate).toBeInstanceOf(Date);
+    expect(converted.appliedDate).toEqual(timestamp.toDate());
+    expect(converted.appliedDate).toEqual(date);
+  });
+
+  it('converts deeply nested Timestamps', () => {
+    const data = {
+      some: {
+        deeply: {
+          nested: {
+            data: {
+              with: {
+                a: {
+                  timestamp: timestamp,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const sanitized = convertFirestoreTimestampsToDates(data);
+
+    expect(sanitized.some.deeply.nested.data.with.a.timestamp).toBeInstanceOf(Date);
+    expect(sanitized.some.deeply.nested.data.with.a.timestamp).toEqual(date);
+  });
+
+  it('leaves other data untouched', () => {
+    const data = {
+      name: 'John Smith',
+      phone: {
+        home: '+441234567890',
+        mobile: '+447890123456',
+      },
+      emails: [
+        'jsmith@gmail.com',
+        'john.smith@outlook.com',
+      ],
+      qtPassed: true,
+      qtScore: 28,
+      aNullValue: null,
+    };
+
+    const sanitized = convertFirestoreTimestampsToDates(data);
+
+    expect(sanitized.name).toEqual('John Smith');
+    expect(sanitized.phone).toEqual({
+      home: '+441234567890',
+      mobile: '+447890123456',
+    });
+    expect(sanitized.emails).toEqual([
+      'jsmith@gmail.com',
+      'john.smith@outlook.com',
+    ]);
+    expect(sanitized.qtPassed).toEqual(true);
+    expect(sanitized.qtScore).toEqual(28);
+    expect(sanitized.aNullValue).toBeNull();
+  });
+
+  it('doesn\'t change the input object (when passed by reference)', () => {
+    const data = {
+      name: 'John Smith',
+      appliedDate: timestamp,
+      qtPassed: true,
+      qtScore: 28,
+    };
+
+    convertFirestoreTimestampsToDates(data);
+
+    expect(data.appliedDate).toBe(timestamp);
+  });
+
+  it('returns a new object', () => {
+    const data = {
+      name: 'John Smith',
+      email: 'johnsmith@example.com',
+    };
+
+    const sanitized = convertFirestoreTimestampsToDates(data);
+
+    expect(sanitized).toEqual(data);
+    expect(sanitized).not.toBe(data);
+  });
+
+  const falsy = [null, undefined, false];
+  it.each(falsy)('does not sanitize falsy value `%s`', (value) => {
+    const sanitized = convertFirestoreTimestampsToDates(value);
+    expect(sanitized).toBe(value);
+  });
+});

--- a/tests/unit/helpers/vuexfireSerialize.spec.js
+++ b/tests/unit/helpers/vuexfireSerialize.spec.js
@@ -1,0 +1,59 @@
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
+import convertFirestoreTimestampsToDates from '@/helpers/convertFirestoreTimestampsToDates';
+import firebase from '@/firebase';
+const Timestamp = firebase.firestore.Timestamp;
+
+const createMockSnapshot = async (data) => {
+  const mockFirebase = (require('firebase-mock')).MockFirebaseSdk();
+  const mockFirestore = mockFirebase.firestore();
+  mockFirestore.autoFlush();
+  const ref = await mockFirestore.collection('documents').add(data);
+  return await ref.get();
+};
+
+jest.mock('@/helpers/convertFirestoreTimestampsToDates', () => {
+  const realMethod = jest.requireActual('@/helpers/convertFirestoreTimestampsToDates').default;
+  return jest.fn(input => {
+    const converted = realMethod(input);
+    converted.__hasBeenConverted = true;
+    return converted;
+  });
+});
+
+describe('@/helpers/vuexfireSerialize', () => {
+  let mockSnapshot;
+  beforeEach(async () => {
+    mockSnapshot = await createMockSnapshot({
+      name: 'Name of exercise',
+      opensAt: Timestamp.fromDate(new Date()),
+    });
+  });
+
+  afterEach(() => {
+    convertFirestoreTimestampsToDates.mockClear();
+  });
+
+  it('is a Function', () => {
+    expect(vuexfireSerialize).toBeInstanceOf(Function);
+  });
+
+  it('accepts a Firestore DocumentSnapshot and returns an Object', () => {
+    expect(vuexfireSerialize(mockSnapshot)).toBeInstanceOf(Object);
+    expect(vuexfireSerialize(mockSnapshot)).not.toBeNull();
+  });
+
+  it('runs snapshot.data() through convertFirestoreTimestampsToDates helper', () => {
+    const serialized = vuexfireSerialize(mockSnapshot);
+    expect(convertFirestoreTimestampsToDates).toHaveBeenCalledWith(mockSnapshot.data());
+    expect(serialized.__hasBeenConverted).toBe(true);
+  });
+
+  it('adds the document ID to the returned object as a non-enumerable property `id`', () => {
+    const serialized = vuexfireSerialize(mockSnapshot);
+    const keys = Object.keys(serialized);
+    expect(keys).toEqual(['name', 'opensAt', '__hasBeenConverted']);
+    expect(keys).not.toContain('id');
+    expect(serialized.id).toBeTruthy();
+    expect(serialized.id).toEqual(mockSnapshot.id);
+  });
+});

--- a/tests/unit/store/exercise/collection.spec.js
+++ b/tests/unit/store/exercise/collection.spec.js
@@ -1,5 +1,6 @@
 import exerciseCollection from '@/store/exercise/collection';
 import { firestore } from '@/firebase';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
 
 jest.mock('@/firebase', () => {
   const firebase = require('firebase-mock');
@@ -15,12 +16,26 @@ describe('store/exercise/collection', () => {
     const actions = exerciseCollection.actions;
 
     describe('bind', () => {
-      it('binds key `records` to the Firestore collection `exercises` ordered by `openAt` descending', () => {
-        const callToBindFirestoreRef = actions.bind();
-        const keyInState = callToBindFirestoreRef[0];
-        const firestoreRef = callToBindFirestoreRef[1];
-        expect(keyInState).toEqual('records');
-        expect(firestoreRef).toEqual(firestore.collection('exercises').orderBy('openAt', 'desc'));
+      describe('binds using vuexfire bindFirestoreRef()', () => {
+        let callToBindFirestoreRef;
+        beforeEach(() => {
+          callToBindFirestoreRef = actions.bind();
+        });
+
+        it('binds to `records` key in the state', () => {
+          const keyInState = callToBindFirestoreRef[0];
+          expect(keyInState).toEqual('records');
+        });
+
+        it('binds the `/exercises` collection', () => {
+          const firestoreRef = callToBindFirestoreRef[1];
+          expect(firestoreRef).toEqual(firestore.collection('exercises'));
+        });
+
+        it('serializes document data with `vuexfireSerialize` helper', () => {
+          const options = callToBindFirestoreRef[2];
+          expect(options.serialize).toBe(vuexfireSerialize);
+        });
       });
     });
 

--- a/tests/unit/store/exercise/document.spec.js
+++ b/tests/unit/store/exercise/document.spec.js
@@ -1,5 +1,6 @@
 import exerciseDocument from '@/store/exercise/document';
 import { firestore } from '@/firebase';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
 
 jest.mock('@/firebase', () => {
   const firebase = require('firebase-mock');
@@ -15,12 +16,26 @@ describe('store/exercise/single', () => {
     const actions = exerciseDocument.actions;
 
     describe('bind', () => {
-      it('binds key `record` to the document with the specified ID in the Firestore `exercises` collection', () => {
-        const callToBindFirestoreRef = actions.bind('TestDocumentID');
-        const keyInState = callToBindFirestoreRef[0];
-        const firestoreRef = callToBindFirestoreRef[1];
-        expect(keyInState).toEqual('record');
-        expect(firestoreRef).toEqual(firestore.collection('exercises').doc('TestDocumentID'));
+      describe('binds using vuexfire bindFirestoreRef()', () => {
+        let callToBindFirestoreRef;
+        beforeEach(() => {
+          callToBindFirestoreRef = actions.bind('TestDocumentID');
+        });
+
+        it('binds to `record` key in the state', () => {
+          const keyInState = callToBindFirestoreRef[0];
+          expect(keyInState).toEqual('record');
+        });
+
+        it('binds the `/exercises` document with the given ID', () => {
+          const firestoreRef = callToBindFirestoreRef[1];
+          expect(firestoreRef).toEqual(firestore.collection('exercises').doc('TestDocumentID'));
+        });
+
+        it('serializes document data with `vuexfireSerialize` helper', () => {
+          const options = callToBindFirestoreRef[2];
+          expect(options.serialize).toBe(vuexfireSerialize);
+        });
       });
     });
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/YHpT0LHD/48-5-sanitize-firestore-timestamps)
Also resolves: [Trello card](https://trello.com/c/TFHD2w3G/99-stop-sorting-exercises-by-openat-field-on-the-dashboard-page)

---

This PR maps Firestore `Timestamp` objects to plain JavaScript `Date` objects.

Most [Firestore field data types](https://firebase.google.com/docs/firestore/manage-data/data-types) map to JavaScript primitive types. However timestamp fields (i.e. date & time) are returned as Firestore [`Timestamp` objects](https://firebase.google.com/docs/reference/js/firebase.firestore.Timestamp).

In this PR, I've implemented functionality to automatically convert each `Timestamp` instance returned by Firestore to an equivalent [JavaScript `Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) instance.

This achieves two things for us:

1. It means our frontend Vue components can be completely database agnostic. They don't need to know about Firestore or how to read/parse `Timestamp` objects. Instead, they can expect to deal with regular `Date` objects. In particular, this applies to the `DateInput` and `TimeInput` components, but will also apply where we display formatted dates to the end user.
2. It enables the Vuex 'time travel' debugging functionality of Vue developer tools. The general recommendation is that complex objects should not be stored in the Vuex state – only primitives should be used. However Vue developer tools does have one exception whereby it allows `Date` objects to be time travel debugged, making this is the only complex object which is safe to use in the state.

### How to use

When using `bindFirestoreRef` to bind to Firestore records, provide an `options` object with the `serialize` key. Use the new custom serialiser `@/helpers/vuexfireSerialize`. All `Timestamp` fields will automatically be converted to `Date` objects.

Example:

```js
import { firestore } from '@/firebase';
import { firestoreAction } from 'vuexfire';
import vuexfireSerialize from '@/helpers/vuexfireSerialize';

export default {
  namespaced: true,
  actions: {
    bind: firestoreAction(({ bindFirestoreRef }) => {
      const firestoreRef = firestore.collection('exercises');
      return bindFirestoreRef('record', firestoreRef, { serialize: vuexfireSerialize });
    }),
  },
  state: {
    record: null,
  },
};
```