### PR TITLE
Add View parent page

### DIFF
--- a/src/components/Page/Navigation.vue
+++ b/src/components/Page/Navigation.vue
@@ -2,7 +2,7 @@
   <nav :aria-label="label">
     <ul class="dwp-vertical-navigation">
       <li 
-        v-for="navItem in data"
+        v-for="navItem in items"
         :key="navItem.name"
       >
         <router-link 
@@ -20,7 +20,7 @@
 <script>
 export default {
   props: {
-    data: {
+    items: {
       required: true,
       type: Array,
     },

--- a/src/components/Page/Navigation.vue
+++ b/src/components/Page/Navigation.vue
@@ -1,0 +1,65 @@
+<template>
+  <nav :aria-label="label">
+    <ul class="dwp-vertical-navigation">
+      <li 
+        v-for="navItem in data"
+        :key="navItem.name"
+      >
+        <router-link 
+          class="nav-link"
+          :to="{name: navItem.name}"
+          :aria-current="isActive(navItem.name) ? 'page' : false"
+        >
+          {{ navItem.page }} 
+        </router-link>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<script>
+export default {
+  props: {
+    data: {
+      required: true,
+      type: Array,
+    },
+    label: {
+      required: false,
+      default: 'navigation',
+      type: String,
+    },
+  },
+  methods: {
+    isActive(name) {
+      return name === this.$route.name;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .dwp-vertical-navigation {
+    margin: 0 0 1.25em 0;
+  }
+
+  .dwp-vertical-navigation li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 1em;
+  }
+
+  .dwp-vertical-navigation a[aria-current="page"] {
+    color: #1d70b8;
+    font-weight: bold;
+    text-decoration: none;
+    border-left: 4px solid #1d70b8;
+    background-color: #f3f2f1;
+  }
+
+  .dwp-vertical-navigation li a {
+    padding: 0.625em;
+    display: block;
+  }
+</style>

--- a/src/main.scss
+++ b/src/main.scss
@@ -56,28 +56,3 @@ body {
 .govuk-input:disabled {
   background-color: #ccc;
 }
-
-// dwp-vertical-navigation
-.dwp-vertical-navigation {
-  margin: 0 0 1.25em 0;
-}
-
-.dwp-vertical-navigation li {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  font-size: 1em;
-}
-
-.dwp-vertical-navigation a[aria-current="page"] {
-  color: #1d70b8;
-  font-weight: bold;
-  text-decoration: none;
-  border-left: 4px solid #1d70b8;
-  background-color: #f3f2f1;
-}
-
-.dwp-vertical-navigation li a {
-  padding: 0.625em;
-  display: block;
-}

--- a/src/main.scss
+++ b/src/main.scss
@@ -55,5 +55,29 @@ body {
 // disabled inputs
 .govuk-input:disabled {
   background-color: #ccc;
+}
 
+// dwp-vertical-navigation
+.dwp-vertical-navigation {
+  margin: 0 0 1.25em 0;
+}
+
+.dwp-vertical-navigation li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 1em;
+}
+
+.dwp-vertical-navigation a[aria-current="page"] {
+  color: #1d70b8;
+  font-weight: bold;
+  text-decoration: none;
+  border-left: 4px solid #1d70b8;
+  background-color: #f3f2f1;
+}
+
+.dwp-vertical-navigation li a {
+  padding: 0.625em;
+  display: block;
 }

--- a/src/router.js
+++ b/src/router.js
@@ -2,15 +2,25 @@ import Vue from 'vue';
 import Router from 'vue-router';
 import store from '@/store';
 
-// Views
+// Edit views
 import ExerciseNew from '@/views/Exercises/New';
-import ExerciseDetails from '@/views/Exercises/Details';
 import ExerciseEdit from '@/views/Exercises/Edit';
 import ExerciseEditContacts from '@/views/Exercises/Edit/Contacts';
 import ExerciseEditShortlisting from '@/views/Exercises/Edit/Shortlisting';
 import ExerciseEditTimeline from '@/views/Exercises/Edit/Timeline';
 import ExerciseEditEligibility from '@/views/Exercises/Edit/Eligibility';
 import ExerciseEditVacancy from '@/views/Exercises/Edit/Vacancy';
+
+// Show views
+import ExerciseShow from '@/views/Exercises/Show';
+import ExerciseShowOverview from '@/views/Exercises/Show/Overview';
+import ExerciseShowApplications from '@/views/Exercises/Show/Applications';
+import ExerciseShowContacts from '@/views/Exercises/Show/Contacts';
+import ExerciseShowTimeline from '@/views/Exercises/Show/Timeline';
+import ExerciseShowShortlisting from '@/views/Exercises/Show/Shortlisting';
+import ExerciseShowVacancy from '@/views/Exercises/Show/Vacancy';
+import ExerciseShowEligibility from '@/views/Exercises/Show/Eligibility';
+
 import Dashboard from '@/views/Dashboard';
 import SignIn from '@/views/SignIn';
 
@@ -44,12 +54,76 @@ const router = new Router({
     },
     {
       path: '/exercises/:id',
-      name: 'exercise-details',
-      component: ExerciseDetails,
+      component: ExerciseShow,
       meta: {
         requiresAuth: true,
-        title: 'View exercise details',
+        title: 'Show exercise details',
       },
+      children: [
+        {
+          path: 'overview',
+          component: ExerciseShowOverview,
+          name: 'exercise-show-overview',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Overview',
+          },
+        },
+        {
+          path: 'applications',
+          component: ExerciseShowApplications,
+          name: 'exercise-show-applications',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Applications',
+          },
+        },
+        {
+          path: 'contacts',
+          component: ExerciseShowContacts,
+          name: 'exercise-show-contacts',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Contacts',
+          },
+        },
+        {
+          path: 'timeline',
+          component: ExerciseShowTimeline,
+          name: 'exercise-show-timeline',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Timeline',
+          },
+        },
+        {
+          path: 'shortlisting',
+          component: ExerciseShowShortlisting,
+          name: 'exercise-show-shortlisting',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Shortlisting',
+          },
+        },
+        {
+          path: 'vacancy',
+          component: ExerciseShowVacancy,
+          name: 'exercise-show-vacancy',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Vacancy information',
+          },
+        },
+        {
+          path: 'eligibility',
+          component: ExerciseShowEligibility,
+          name: 'exercise-show-eligibility',
+          meta: {
+            requiresAuth: true,
+            title: 'Exercise Details | Eligibility information',
+          },
+        },
+      ],
     },
     {
       path: '/exercises/:id/edit',

--- a/src/router.js
+++ b/src/router.js
@@ -61,6 +61,10 @@ const router = new Router({
       },
       children: [
         {
+          path: '',
+          redirect: { name: 'exercise-show-overview' }
+        },
+        {
           path: 'overview',
           component: ExerciseShowOverview,
           name: 'exercise-show-overview',

--- a/src/router.js
+++ b/src/router.js
@@ -55,17 +55,9 @@ const router = new Router({
     {
       path: '/exercises/:id',
       component: ExerciseShow,
-      meta: {
-        requiresAuth: true,
-        title: 'Show exercise details',
-      },
       children: [
         {
           path: '',
-          redirect: { name: 'exercise-show-overview' }
-        },
-        {
-          path: 'overview',
           component: ExerciseShowOverview,
           name: 'exercise-show-overview',
           meta: {

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -25,7 +25,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
           <Navigation
-            :data="navPages"
+            :items="navPages"
             label="Main Navigation"
           />
         </div>
@@ -60,9 +60,13 @@ export default {
     return {
       loaded: false,
       loadFailed: false,
-      exercise: {},
       navPages,
     };
+  },
+  computed: {
+    exercise() {
+      return this.$store.state.exerciseDocument.record;
+    },
   },
   mounted() {
     const id = this.$route.params.id;
@@ -70,7 +74,6 @@ export default {
     this.$store.dispatch('exerciseDocument/bind', id)
       .then(() => {
         this.loaded = true;
-        this.exercise = this.$store.state.exerciseDocument.record;
       }).catch((e) => {
         this.loadFailed = true;
         throw e;

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -1,0 +1,97 @@
+<template>
+  <div>
+    <LoadingMessage
+      v-if="loaded === false"
+      ref="loadingMessageComponent"
+      :load-failed="loadFailed"
+    />
+    <div v-else>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="text-right govuk-!-margin-0">
+            <a
+              href="#"
+              class="govuk-button govuk-button--secondary govuk-!-margin-0"
+            >
+              ☆ Add to favourites
+            </a>
+          </div>
+          <span class="govuk-caption-xl">118</span>
+          <h1 class="govuk-heading-xl">
+            {{ exercise.name }}
+          </h1>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter">
+          <nav aria-label="Main Navigation">
+            <ul class="dwp-vertical-navigation">
+              <router-link 
+                v-for="navItem in navPages"
+                :key="navItem.name"
+                :to="{name: navItem.name}"
+                tag="li"
+              >
+                <a 
+                  :aria-current="isActive(navItem.name) ? 'page' : false"
+                >
+                  {{ navItem.page }} 
+                </a>
+              </router-link>
+            </ul>
+          </nav>
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+          <RouterView />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import LoadingMessage from '@/components/LoadingMessage';
+export default {
+  components: {
+    LoadingMessage,
+  },
+  data() {
+    const navPages = [
+      { page: 'Overview', name: 'exercise-show-overview' },
+      { page: 'Applications', name: 'exercise-show-applications' },
+      { page: 'Contacts', name: 'exercise-show-contacts' },
+      { page: 'Timeline', name: 'exercise-show-timeline' },
+      { page: 'Shortlisting', name: 'exercise-show-shortlisting' },
+      { page: 'Vacancy information', name: 'exercise-show-vacancy' },
+      { page: 'Eligibility information', name: 'exercise-show-eligibility' },
+    ];
+
+    return {
+      loaded: false,
+      loadFailed: false,
+      exercise: {},
+      navPages,
+    };
+  },
+  mounted() {
+    const id = this.$route.params.id;
+    
+    this.$store.dispatch('exerciseDocument/bind', id)
+      .then(() => {
+        this.loaded = true;
+        this.exercise = this.$store.state.exerciseDocument.record;
+      }).catch((e) => {
+        this.loadFailed = true;
+        throw e;
+      });
+
+    // to display overview page
+    this.$router.push({ name: 'exercise-show-overview' })
+  },
+  methods: {
+    isActive(name) {
+      return name === this.$route.name;
+    },
+  },
+};
+</script>

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -84,9 +84,6 @@ export default {
         this.loadFailed = true;
         throw e;
       });
-
-    // to display overview page
-    this.$router.push({ name: 'exercise-show-overview' })
   },
   methods: {
     isActive(name) {

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -24,22 +24,10 @@
       </div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
-          <nav aria-label="Main Navigation">
-            <ul class="dwp-vertical-navigation">
-              <router-link 
-                v-for="navItem in navPages"
-                :key="navItem.name"
-                :to="{name: navItem.name}"
-                tag="li"
-              >
-                <a 
-                  :aria-current="isActive(navItem.name) ? 'page' : false"
-                >
-                  {{ navItem.page }} 
-                </a>
-              </router-link>
-            </ul>
-          </nav>
+          <Navigation
+            :data="navPages"
+            label="Main Navigation"
+          />
         </div>
         <div class="govuk-grid-column-three-quarters">
           <RouterView />
@@ -51,9 +39,12 @@
 
 <script>
 import LoadingMessage from '@/components/LoadingMessage';
+import Navigation from '@/components/Page/Navigation';
+
 export default {
   components: {
     LoadingMessage,
+    Navigation,
   },
   data() {
     const navPages = [
@@ -84,11 +75,6 @@ export default {
         this.loadFailed = true;
         throw e;
       });
-  },
-  methods: {
-    isActive(name) {
-      return name === this.$route.name;
-    },
   },
 };
 </script>

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -2,7 +2,6 @@
   <div>
     <LoadingMessage
       v-if="loaded === false"
-      ref="loadingMessageComponent"
       :load-failed="loadFailed"
     />
     <div v-else>

--- a/src/views/Exercises/Show/Applications.vue
+++ b/src/views/Exercises/Show/Applications.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Applications
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Contacts.vue
+++ b/src/views/Exercises/Show/Contacts.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Contacts
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Eligibility.vue
+++ b/src/views/Exercises/Show/Eligibility.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Eligibility information
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Overview.vue
+++ b/src/views/Exercises/Show/Overview.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Overview
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Shortlisting.vue
+++ b/src/views/Exercises/Show/Shortlisting.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Shortlisting
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Timeline.vue
+++ b/src/views/Exercises/Show/Timeline.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Timeline
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/src/views/Exercises/Show/Vacancy.vue
+++ b/src/views/Exercises/Show/Vacancy.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Vacancy information
+  </div>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/tests/unit/components/Page/Navigation.spec.js
+++ b/tests/unit/components/Page/Navigation.spec.js
@@ -22,7 +22,7 @@ const createTestSubject = (propsData) => {
 
 describe('components/Page/Navigation', () => {
   it('renders the component', () => {
-    let wrapper = createTestSubject({ data: navPages });
+    let wrapper = createTestSubject({ items: navPages });
     expect(wrapper.exists()).toBe(true);
   });
 
@@ -31,7 +31,7 @@ describe('components/Page/Navigation', () => {
 
     describe('data', () => {
       beforeEach(() => {
-        prop = Navigation.props.data;
+        prop = Navigation.props.items;
       });
 
       it('is required', () => {
@@ -62,27 +62,25 @@ describe('components/Page/Navigation', () => {
     });
   });
 
-  describe('markup', () => {
-    it('renders data that is passed as prop', () => {
-      let wrapper = createTestSubject({ data: navPages });
+  describe('template', () => {
+    it('renders items that is passed as prop', () => {
+      let wrapper = createTestSubject({ items: navPages });
       expect(wrapper.findAll('li').length).toBe(2);
     });
 
-    it('does not render if data array is empty', () => {
-      let wrapper = createTestSubject({ data: [] });
+    it('does not render if items array is empty', () => {
+      let wrapper = createTestSubject({ items: [] });
       expect(wrapper.findAll('li').length).toBe(0);
     });
 
     it('sets aria-label with label prop', () => {
-      let wrapper = createTestSubject({ data: navPages, label: 'MyTestLabel' });
+      let wrapper = createTestSubject({ items: navPages, label: 'MyTestLabel' });
       expect(wrapper.find('nav').attributes('aria-label')).toBe('MyTestLabel');
     });
-  });
 
-  describe('Accessibility', () => {
     describe('aria-current attribute', () => {
       it('is set for a link which is currently active', () => {
-        let wrapper = createTestSubject({ data: navPages });
+        let wrapper = createTestSubject({ items: navPages });
         let links = wrapper.findAll('.nav-link');
         expect(links.at(0).attributes()).toHaveProperty('aria-current');
         expect(links.at(1).attributes()).not.toHaveProperty('aria-current');

--- a/tests/unit/components/Page/Navigation.spec.js
+++ b/tests/unit/components/Page/Navigation.spec.js
@@ -1,0 +1,92 @@
+import { shallowMount } from '@vue/test-utils';
+import Navigation from '@/components/Page/Navigation';
+
+const navPages = [
+  { page: 'Test', name: 'nav-test-name1' },
+  { page: 'Test2', name: 'nav-test-name2' },
+];
+
+const createTestSubject = (propsData) => {
+  return shallowMount(Navigation, {
+    propsData: {
+      ...propsData,
+    },
+    stubs: ['RouterLink'],
+    mocks: {
+      $route: {
+        name: 'nav-test-name1',
+      },
+    },
+  });
+};
+
+describe('components/Page/Navigation', () => {
+  it('renders the component', () => {
+    let wrapper = createTestSubject({ data: navPages });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe('properties', () => {
+    let prop;
+
+    describe('data', () => {
+      beforeEach(() => {
+        prop = Navigation.props.data;
+      });
+
+      it('is required', () => {
+        expect(prop.required).toBe(true);
+      });
+
+      it('should be array', () => {
+        expect(prop.type).toBe(Array);
+      });
+    });
+
+    describe('label', () => {
+      beforeEach(() => {
+        prop = Navigation.props.label;
+      });
+
+      it('is optional', () => {
+        expect(prop.required).not.toBe(true);
+      });
+
+      it('has default value', () => {
+        expect(prop.default).toBe('navigation');
+      });
+
+      it('should be string', () => {
+        expect(prop.type).toBe(String);
+      });
+    });
+  });
+
+  describe('markup', () => {
+    it('renders data that is passed as prop', () => {
+      let wrapper = createTestSubject({ data: navPages });
+      expect(wrapper.findAll('li').length).toBe(2);
+    });
+
+    it('does not render if data array is empty', () => {
+      let wrapper = createTestSubject({ data: [] });
+      expect(wrapper.findAll('li').length).toBe(0);
+    });
+
+    it('sets aria-label with label prop', () => {
+      let wrapper = createTestSubject({ data: navPages, label: 'MyTestLabel' });
+      expect(wrapper.find('nav').attributes('aria-label')).toBe('MyTestLabel');
+    });
+  });
+
+  describe('Accessibility', () => {
+    describe('aria-current attribute', () => {
+      it('is set for a link which is currently active', () => {
+        let wrapper = createTestSubject({ data: navPages });
+        let links = wrapper.findAll('.nav-link');
+        expect(links.at(0).attributes()).toHaveProperty('aria-current');
+        expect(links.at(1).attributes()).not.toHaveProperty('aria-current');
+      });
+    });
+  });
+});

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -157,8 +157,8 @@ describe('Page titles', () => {
       router.push('/exercises/abc123');
     });
 
-    it('sets title as About The Selection Process', () => {
-      expect(document.title).toContain('View exercise details');
+    it('sets title as Exercise Details | Overview', () => {
+      expect(document.title).toContain('Exercise Details | Overview');
     });
 
     it('contains Judicial Appointments Commission', () => {

--- a/tests/unit/views/Exercises/Show.spec.js
+++ b/tests/unit/views/Exercises/Show.spec.js
@@ -37,10 +37,22 @@ const createTestSubject = () => {
     store,
     localVue,
     router,
+    stubs: {
+      'RouterView': true,
+    },
   });
 };
 
 describe('@/views/Exercises/Show', () => {
+  describe('computed properties', () => {
+    describe('exercise', () => {
+      it('returns record object from state', () => {
+        let wrapper = createTestSubject();
+        expect(wrapper.vm.exercise).toEqual(exercise);
+      });
+    });
+  });
+
   describe('template', () => {
     describe('when loaded is false', () => {
       it('renders LoadingMessage component', () => {
@@ -50,18 +62,24 @@ describe('@/views/Exercises/Show', () => {
     });
 
     describe('when loaded is true', () => {
-      it('renders LoadingMessage component', () => {
-        let wrapper = createTestSubject();
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = createTestSubject();
         wrapper.setData({ loaded: true });
+      });
+
+      it('does not render LoadingMessage component', () => {
         expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(false);
       });
-    });
-  });
 
-  describe('Navigation component',() => {
-    it('renders', () => {
-      let wrapper = createTestSubject();
-      expect(wrapper.find(Navigation).exists()).toBe(false);
+      it('renders the Navigation component', () => {
+        expect(wrapper.find(Navigation).exists()).toBe(true);
+      });
+
+      it('renders the RouterView', () => {
+        expect(wrapper.find('RouterView-stub').exists()).toBe(true);
+      });
     });
   });
 });

--- a/tests/unit/views/Exercises/Show.spec.js
+++ b/tests/unit/views/Exercises/Show.spec.js
@@ -3,6 +3,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Router from 'vue-router';
 import Vuex from 'vuex';
 import Navigation from '@/components/Page/Navigation';
+import LoadingMessage from '@/components/LoadingMessage';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -57,7 +58,12 @@ describe('@/views/Exercises/Show', () => {
     describe('when loaded is false', () => {
       it('renders LoadingMessage component', () => {
         let wrapper = createTestSubject();
-        expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(true);
+        expect(wrapper.find(LoadingMessage).exists()).toBe(true);
+      });
+
+      it('does not render the RouterView', () => {
+        let wrapper = createTestSubject();
+        expect(wrapper.find('RouterView-stub').exists()).toBe(false);
       });
     });
 

--- a/tests/unit/views/Exercises/Show.spec.js
+++ b/tests/unit/views/Exercises/Show.spec.js
@@ -1,0 +1,67 @@
+import Show from '@/views/Exercises/Show';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Router from 'vue-router';
+import Vuex from 'vuex';
+import Navigation from '@/components/Page/Navigation';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(Router);
+
+const router = new Router();
+const exercise = {
+  name: 'test name',
+};
+
+const store = new Vuex.Store({
+  dispatch: jest.fn(),
+  modules: {
+    exerciseDocument: {
+      namespaced: true,
+      actions: {
+        bind: () => {
+          new Promise((resolve) => {
+            return resolve();
+          });
+        },
+      },
+      state: {
+        record: exercise,
+      },
+    },
+  },
+});
+
+const createTestSubject = () => {
+  return shallowMount(Show, {
+    store,
+    localVue,
+    router,
+  });
+};
+
+describe('@/views/Exercises/Show', () => {
+  describe('template', () => {
+    describe('when loaded is false', () => {
+      it('renders LoadingMessage component', () => {
+        let wrapper = createTestSubject();
+        expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(true);
+      });
+    });
+
+    describe('when loaded is true', () => {
+      it('renders LoadingMessage component', () => {
+        let wrapper = createTestSubject();
+        wrapper.setData({ loaded: true });
+        expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(false);
+      });
+    });
+  });
+
+  describe('Navigation component',() => {
+    it('renders', () => {
+      let wrapper = createTestSubject();
+      expect(wrapper.find(Navigation).exists()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a parent Show page and empty templates for child components.

**Change log**
1) Create Navigation component 
2) Create Edit page that uses Navigation component and displays Overview child page by default

