### PR TITLE
Amended the Currency component.

### DIFF
--- a/src/components/Form/Currency.vue
+++ b/src/components/Form/Currency.vue
@@ -32,7 +32,7 @@ export default {
     },
     value: {
       default: null,
-      type: Number,
+      type: String,
     },
     hint: {
       default: '',

--- a/tests/unit/components/Form/Currency.spec.js
+++ b/tests/unit/components/Form/Currency.spec.js
@@ -62,8 +62,8 @@ describe('components/Form/Currency', () => {
   describe('`v-model` interface', () => {
     describe('when `currencyInput` changes', () => {
       it('emits an input event with the new value', () => {
-        wrapper.setData({ currencyInput: 25 });
-        expect(wrapper.emitted().input).toEqual([[25]]);
+        wrapper.setData({ currencyInput: '25' });
+        expect(wrapper.emitted().input).toEqual([['25']]);
       });
     });
 


### PR DESCRIPTION
We were receiving an error when using the currency component, due to it 
expecting a number rather than a string. 

- I've amended the component's Value Prop only, to expect a string. I've 
left the type as number in order to keep accessibility features that 
come with this. 

- I've amended the test to expect a string rather than a number to be 
more accurate (Not sure why the number ones were still passing tbh?)

Tests are passing and code has been linted

🌻 