### PR TITLE
Scroll functionality

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -193,6 +193,13 @@ const router = new Router({
       },
     },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    } else {
+      return { x: 0, y: 0 };
+    }
+  },  
 });
 
 // Global before guard to verify if a user can have access to other than sign-in pages.

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -14,7 +14,7 @@ describe('Page titles', () => {
 
     router = require('@/router').default;
     store = require('@/store').default;
-
+    window.scrollTo = () => {};
     shallowMount(App, {
       localVue,
       router,

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -15,7 +15,7 @@ describe('Sign in journey', () => {
 
     router = require('@/router').default;
     store = require('@/store').default;
-
+    window.scrollTo = () => {};
     subject = shallowMount(App, {
       localVue,
       router,


### PR DESCRIPTION
Copied the scrollBehavior method from the router of the digital platform, and implemented it in the router of apply-admin. 

Tests have not been written for this, and will be addressed later when refactoring the router tests. 

When user testing this, the page will return to the top if the submit button redirects successfully to a new page, and will stay at the bottom on the new page if the scrollBehavior method is absent. It does not work however, if you manually change the urls 🤷‍♀. 

Code has been linted.
All tests are still passing however: 

We were getting a: 

```console.error node_modules/jsdom/lib/jsdom/virtual-console.js:29
      Error: Not implemented: window.scrollTo
``` 
 console error under the signin.spec.js and the page-titles.spec files. After consulting with Ollie and Alex, I've added a 'window.scrollTo' object to line 17 of the page-titles.spec  and line 18 of the signin.spec. This stops the error but we will need to address what we can do to resolve this once the Router tests are refactored. 

🌻 