### PR TITLE
Checkbox Bug

### DIFF
--- a/src/components/Form/CheckboxGroup.vue
+++ b/src/components/Form/CheckboxGroup.vue
@@ -45,7 +45,7 @@ export default {
     },
     value: {
       required: true,
-      validator: value => (value instanceof Array || value === null || value === undefined),
+      validator: (value) => (value instanceof Array || value === null || value === undefined),
     },
   },
   computed: {
@@ -60,6 +60,11 @@ export default {
     hintId() {
       return `${this.id}__hint`;
     },
+  },
+  created() {
+    if (this.value === null || this.value === undefined) {
+      this.$emit('input', []);
+    }
   },
 };
 </script>

--- a/src/components/Form/CheckboxGroup.vue
+++ b/src/components/Form/CheckboxGroup.vue
@@ -21,7 +21,7 @@
         {{ hint }}
       </span>
       <div class="govuk-checkboxes">
-        <slot />
+        <slot v-if="inputValue instanceof Array" />
       </div>
     </fieldset>
   </div>
@@ -62,7 +62,7 @@ export default {
     },
   },
   created() {
-    if (this.value === null || this.value === undefined) {
+    if (!(this.value instanceof Array)) {
       this.$emit('input', []);
     }
   },

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -6,9 +6,9 @@
           Add eligibility information
         </h1>
 
-      <p class="govuk-body-l">
-        You'll find this information in the eligibility statement from HMCTS.
-      </p>
+        <p class="govuk-body-l">
+          You'll find this information in the eligibility statement from HMCTS.
+        </p>
 
         <RadioGroup
           id="post-qualification-experience"

--- a/src/views/Exercises/Edit/Shortlisting.vue
+++ b/src/views/Exercises/Edit/Shortlisting.vue
@@ -84,7 +84,7 @@ export default {
         OtherShortlistingMethod,
       },
       exercise: {
-        shortlistingMethods: exercise.shortlistingMethods || [],
+        shortlistingMethods: exercise.shortlistingMethods || null,
         otherShortlistingMethod: exercise.otherShortlistingMethod || null,
       },
     };

--- a/tests/unit/components/Form/CheckboxGroup.spec.js
+++ b/tests/unit/components/Form/CheckboxGroup.spec.js
@@ -219,22 +219,6 @@ describe('components/Form/CheckboxGroup', () => {
       });
     });
 
-    describe('created hook', () => {
-      describe('if value is an array', () => {
-        it('does not call emit', ()=> {
-          let array = [];
-          let wrapper = createTestSubject({ value: array });
-          expect(wrapper.emitted().input).not.toBeTruthy();
-        });
-      });
-      describe('if value is not an array', () => {
-        it('emits the initial empty array value', ()=> {
-          let wrapper = createTestSubject({ value: undefined });
-          expect(wrapper.emitted().input).toBeTruthy();
-        });
-      });
-    });
-
     describe('`.govuk-checkboxes` slot container', () => {
       describe('if value is an array ', () => {
         let slotContainer;
@@ -274,6 +258,24 @@ describe('components/Form/CheckboxGroup', () => {
           expect(slotContainer.text()).toBe('');
         });
 
+      });
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    describe('created', () => {
+      describe('if value is an array', () => {
+        it('does not call emit', ()=> {
+          let array = [];
+          let wrapper = createTestSubject({ value: array });
+          expect(wrapper.emitted().input).not.toBeTruthy();
+        });
+      });
+      describe('if value is not an array', () => {
+        it('emits the initial empty array value', ()=> {
+          let wrapper = createTestSubject({ value: undefined });
+          expect(wrapper.emitted().input).toBeTruthy();
+        });
       });
     });
   });

--- a/tests/unit/components/Form/CheckboxGroup.spec.js
+++ b/tests/unit/components/Form/CheckboxGroup.spec.js
@@ -219,24 +219,61 @@ describe('components/Form/CheckboxGroup', () => {
       });
     });
 
+    describe('created hook', () => {
+      describe('if value is an array', () => {
+        it('does not call emit', ()=> {
+          let array = [];
+          let wrapper = createTestSubject({ value: array });
+          expect(wrapper.emitted().input).not.toBeTruthy();
+        });
+      });
+      describe('if value is not an array', () => {
+        it('emits the initial empty array value', ()=> {
+          let wrapper = createTestSubject({ value: undefined });
+          expect(wrapper.emitted().input).toBeTruthy();
+        });
+      });
+    });
+
     describe('`.govuk-checkboxes` slot container', () => {
-      let slotContainer;
-      beforeEach(() => {
-        subject = createTestSubject();
-        slotContainer = subject.find('.govuk-checkboxes');
+      describe('if value is an array ', () => {
+        let slotContainer;
+        beforeEach(() => {
+          subject = createTestSubject();
+          slotContainer = subject.find('.govuk-checkboxes');
+        });
+
+        it('exists', () => {
+          expect(slotContainer.exists()).toBe(true);
+        });
+
+        it('renders default slot content', () => {
+          expect(slotContainer.text()).toBe('CheckboxItem components');
+        });
+
+        it('is inside the <fieldset>', () => {
+          const fieldset = subject.find('fieldset');
+          expect(fieldset.find('.govuk-checkboxes').exists()).toBe(true);
+        });
+
       });
 
-      it('exists', () => {
-        expect(slotContainer.exists()).toBe(true);
-      });
+      describe('if value is not an array ', () => {
+        let slotContainer;
 
-      it('renders default slot content', () => {
-        expect(slotContainer.text()).toBe('CheckboxItem components');
-      });
+        beforeEach(() => {
+          subject = createTestSubject({ value: null });
+          slotContainer = subject.find('.govuk-checkboxes');
+        });
 
-      it('is inside the <fieldset>', () => {
-        const fieldset = subject.find('fieldset');
-        expect(fieldset.find('.govuk-checkboxes').exists()).toBe(true);
+        it('exists', () => {
+          expect(slotContainer.exists()).toBe(true);
+        });
+
+        it('does not render slot content', () => {
+          expect(slotContainer.text()).toBe('');
+        });
+
       });
     });
   });


### PR DESCRIPTION
This mighty bug 🐛 was causing our checkboxes to be plagued with a lack of flexibility. 

- Initially, the CheckboxGroup would have a lil fit if you initialised it with anything other than an empty array. To amend this, I've added a created method to the CheckboxGroup component that will emit it's value to be an empty array if it's set to anything that's not an array. This way, you can initialise it to whatever you fancy but at the end of the day, he'll be a big bad empty array, ready for some input. 

- Next issue was that the CheckboxItems were getting all picky about the CheckboxGroup value being set to null, but this was because they were checking the value of the CheckboxGroup before it had a chance to change itself to an empty array. To stop them being so damn hasty, we've added a v-if to the CheckboxGroup's item slot, to only render if the value is an array. 

This seemed to fix it. 

- Code has been linted.
- No additional tests have been written, not have originals been refactored, however they still pass. 
- Shortlisting.vue has been edited in order to test this new null acceptance. 

🌻 