### PR TITLE
'Create an exercise' journey functionality

### DIFF
--- a/src/store/exercise/createJourney.js
+++ b/src/store/exercise/createJourney.js
@@ -1,18 +1,77 @@
-/* eslint-disable */
+// For improved readability, this module deals with page names without their prefix
+// All route names are prefixed with this string before navigation
+const routeNamePrefix = 'exercise-edit-';
+
+// This is the complete journey available, sorted in order
+// Partial journeys should still follow this order, skipping pages which weren't selected by the user
+const completeJourneyInOrder = [
+  'contacts',
+  'shortlisting',
+  'timeline',
+  'vacancy',
+  'eligibility',
+];
+
+const routeLocation = (name, id) => {
+  return {
+    name,
+    params: { id },
+  };
+};
+
 export default {
   namespaced: true,
   state: {
-    journeyPages: [],
+    journey: [],
     currentPage: null,
   },
   mutations: {
-    setJourneyPages({ commit }, pages) {},
-    setCurrentPage({ commit }, page) {},
-    reset({ commit }) {},
+    setJourney(state, journey) {
+      state.journey = journey;
+      state.currentPage = null;
+    },
+    setCurrentPage(state, page) {
+      state.currentPage = page;
+    },
+  },
+  actions: {
+    start({ commit }, pages) {
+      // Sort the selected pages into the correct order for the journey
+      const journey = completeJourneyInOrder.filter((page) => {
+        return pages.indexOf(page) !== -1;
+      });
+      commit('setJourney', journey);
+    },
+    setCurrentRoute({ commit }, name) {
+      // Trim routeNamePrefix off the beginning of the route name
+      if (name.indexOf(routeNamePrefix) === 0) {
+        name = name.slice(routeNamePrefix.length);
+      }
+      commit('setCurrentPage', name);
+    },
   },
   getters: {
-    nextPage() {},
-    previousPage() {},
-    isInProgress() {},
+    currentPageIndex(state) {
+      return state.journey.indexOf(state.currentPage);
+    },
+    nextPageIndex(state, getters) {
+      const currentIndex = getters.currentPageIndex;
+      const journeyLength = state.journey.length;
+      if ((currentIndex + 1) < journeyLength) {
+        return (currentIndex + 1);
+      } else {
+        return null;
+      }
+    },
+    nextPage(state, getters, rootState, rootGetters) {
+      const id = rootGetters['exerciseDocument/id'];
+      if (id === null) return null;
+
+      const pageIndex = getters.nextPageIndex;
+      if (pageIndex === null) return routeLocation('exercise-show-overview', id);
+
+      const name = state.journey[pageIndex];
+      return routeLocation(routeNamePrefix + name, id);
+    },
   },
 };

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -27,4 +27,10 @@ export default {
   state: {
     record: null,
   },
+  getters: {
+    id: (state) => {
+      if (state.record === null) return null;
+      return state.record.id;
+    },
+  },
 };

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -20,6 +20,11 @@ export default {
       loadFailed: false,
     };
   },
+  watch: {
+    '$route': function (newRoute) {
+      this.$store.dispatch('exerciseCreateJourney/setCurrentRoute', newRoute.name);
+    },
+  },
   mounted() {
     const id = this.$route.params.id;
     
@@ -30,6 +35,8 @@ export default {
         this.loadFailed = true;
         throw e;
       });
+
+    this.$store.dispatch('exerciseCreateJourney/setCurrentRoute', this.$route.name);
   },
 };
 </script>

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -2,7 +2,6 @@
   <div>
     <LoadingMessage
       v-if="loaded === false"
-      ref="loadingMessageComponent"
       :load-failed="loadFailed"
     />
     <RouterView v-else />

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -179,6 +179,7 @@ export default {
   methods: {
     async save() {
       await this.$store.dispatch('exerciseDocument/save', this.exercise);
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -200,6 +200,7 @@ export default {
   methods: {
     async save() {
       await this.$store.dispatch('exerciseDocument/save', this.exercise);
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/src/views/Exercises/Edit/Shortlisting.vue
+++ b/src/views/Exercises/Edit/Shortlisting.vue
@@ -92,6 +92,7 @@ export default {
   methods: {
     async save() {
       await this.$store.dispatch('exerciseDocument/save', this.exercise);
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -196,6 +196,7 @@ export default {
   methods: {
     async save() {
       await this.$store.dispatch('exerciseDocument/save', this.exercise);
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -338,6 +338,7 @@ export default {
   methods: {
     async save() {
       await this.$store.dispatch('exerciseDocument/save', this.exercise);
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/src/views/Exercises/New.vue
+++ b/src/views/Exercises/New.vue
@@ -42,11 +42,11 @@
               hint="Select all that apply."
             >
               <CheckboxItem
-                value="exercise-contacts"
+                value="contacts"
                 label="Exercise contacts"
               />
               <CheckboxItem
-                value="shortlisting-methods"
+                value="shortlisting"
                 label="Shortlisting methods"
               />
               <CheckboxItem
@@ -54,11 +54,11 @@
                 label="Timeline"
               />
               <CheckboxItem
-                value="vacancy-information"
+                value="vacancy"
                 label="Vacancy information"
               />
               <CheckboxItem
-                value="eligibility-information"
+                value="eligibility"
                 label="Eligibility Information"
               />
             </CheckboxGroup>
@@ -105,6 +105,11 @@ export default {
         name: this.exerciseName,
       };
       await this.$store.dispatch('exerciseDocument/create', data);
+
+      const selectedPages = this.addMoreInfo ? this.addMoreInfoSelection : [];
+      this.$store.dispatch('exerciseCreateJourney/start', selectedPages);
+
+      this.$router.push(this.$store.getters['exerciseCreateJourney/nextPage']);
     },
   },
 };

--- a/tests/unit/store/exercise/createJourney.spec.js
+++ b/tests/unit/store/exercise/createJourney.spec.js
@@ -4,4 +4,215 @@ describe('store/exercise/createJourney', () => {
   it('is namespaced', () => {
     expect(exerciseCreateJourney.namespaced).toBe(true);
   });
+
+  describe('mutations', () => {
+    describe('setJourney', () => {
+      let state;
+      beforeEach(() => {
+        state = {
+          journey: [],
+          currentPage: 'some-page',
+        };
+        const journey = ['shortlisting', 'timeline'];
+        exerciseCreateJourney.mutations.setJourney(state, journey);
+      });
+
+      it('sets `state.journey` to the supplied value', () => {
+        expect(state.journey).toEqual(['shortlisting', 'timeline']);
+      });
+
+      it('sets `state.currentPage` to `null`', () => {
+        expect(state.currentPage).toBeNull();
+      });
+    });
+
+    describe('setCurrentPage', () => {
+      it('sets `state.currentPage` to the supplied value', () => {
+        const state = {
+          currentPage: null,
+        };
+        exerciseCreateJourney.mutations.setCurrentPage(state, 'some-page');
+        expect(state.currentPage).toEqual('some-page');
+      });
+    });
+  });
+
+  describe('actions', () => {
+    let context;
+    beforeEach(() => {
+      context = {
+        commit: jest.fn(),
+      };
+    });
+
+    describe('start', () => {
+      it('calls mutation `setJourney` with the supplied journey array', () => {
+        const journey = [
+          'timeline',
+        ];
+        exerciseCreateJourney.actions.start(context, journey);
+        expect(context.commit).toHaveBeenCalledWith('setJourney', journey);
+      });
+
+      describe('sorts the journey into the expected order', () => {
+        /**
+         * The expected complete linear journey is:
+         *  1. contacts
+         *  2. shortlisting
+         *  3. timeline
+         *  4. vacancy
+         *  5. eligibility
+         */
+        const variations = [
+          [
+            'a 2 page journey',
+            ['timeline', 'shortlisting'],
+            ['shortlisting', 'timeline'],
+          ],
+          [
+            'a 3 page journey',
+            ['timeline', 'vacancy', 'contacts'],
+            ['contacts', 'timeline', 'vacancy'],
+          ],
+          [
+            'a complete journey',
+            ['eligibility', 'shortlisting', 'vacancy', 'timeline', 'contacts'],
+            ['contacts', 'shortlisting', 'timeline', 'vacancy', 'eligibility'],
+          ],
+          [
+            'a complete journey (already in order)',
+            ['contacts', 'shortlisting', 'timeline', 'vacancy', 'eligibility'],
+            ['contacts', 'shortlisting', 'timeline', 'vacancy', 'eligibility'],
+          ],
+          [
+            'a 1 page journey',
+            ['timeline'],
+            ['timeline'],
+          ],
+          [
+            'an empty journey',
+            [],
+            [],
+          ],
+        ];
+
+        it.each(variations)('%s is sorted correctly', (label, pages, expectSorted) => {
+          exerciseCreateJourney.actions.start(context, pages);
+          expect(context.commit.mock.calls[0][1]).toEqual(expectSorted);
+        });
+      });
+    });
+
+    describe('setCurrentRoute', () => {
+      it('calls mutation `setCurrentPage` with the journey page name', () => {
+        exerciseCreateJourney.actions.setCurrentRoute(context, 'exercise-edit-timeline');
+        expect(context.commit).toHaveBeenCalledWith('setCurrentPage', 'timeline');
+      });
+
+      it('converts route name to a journey page name by trimming "exercise-edit-" off the beginning', () => {
+        const routeName = 'exercise-edit-timeline';
+        const pageName = 'timeline';
+        exerciseCreateJourney.actions.setCurrentRoute(context, routeName);
+        expect(context.commit.mock.calls[0][1]).toBe(pageName);
+      });
+    });
+  });
+
+  describe('getters', () => {
+    describe('currentPageIndex', () => {
+      const state = {
+        journey: ['contacts', 'timeline', 'vacancy'],
+      };
+      const currentPageIndex = () => (exerciseCreateJourney.getters.currentPageIndex(state));
+
+      it('returns the index of the current page within the journey', () => {
+        state.currentPage = 'contacts';
+        expect(currentPageIndex()).toBe(0);
+
+        state.currentPage = 'timeline';
+        expect(currentPageIndex()).toBe(1);
+
+        state.currentPage = 'vacancy';
+        expect(currentPageIndex()).toBe(2);
+      });
+
+      it('returns -1 when the current page is null or does not exist in the journey', () => {
+        state.currentPage = null;
+        expect(currentPageIndex()).toBe(-1);
+
+        state.currentPage = 'eligibility';
+        expect(currentPageIndex()).toBe(-1);
+      });
+    });
+
+    describe('nextPageIndex', () => {
+      const state = {
+        journey: ['contacts', 'timeline', 'vacancy'],
+      };
+      const getters = {
+        currentPageIndex: -1,
+      };
+      const nextPageIndex = () => (exerciseCreateJourney.getters.nextPageIndex(state, getters));
+
+      it('returns the index of the next page in the journey', () => {
+        getters.currentPageIndex = -1;
+        expect(nextPageIndex()).toBe(0);
+
+        getters.currentPageIndex = 0;
+        expect(nextPageIndex()).toBe(1);
+
+        getters.currentPageIndex = 1;
+        expect(nextPageIndex()).toBe(2);
+      });
+
+      it('returns null when the current page is the last in the journey', () => {
+        getters.currentPageIndex = 2;
+        expect(nextPageIndex()).toBeNull();
+      });
+    });
+
+    describe('nextPage', () => {
+      const state = {
+        journey: ['contacts', 'timeline', 'vacancy'],
+      };
+      const getters = {
+        currentPageIndex: 0,
+        nextPageIndex: 1,
+      };
+      const rootState = {};
+      const rootGetters = {
+        'exerciseDocument/id': null,
+      };
+      const nextPage = () => (exerciseCreateJourney.getters.nextPage(state, getters, rootState, rootGetters));
+
+      describe('when no document is bound to `exerciseDocument`', () => {
+        it('returns null', () => {
+          rootGetters['exerciseDocument/id'] = null;
+          expect(nextPage()).toBeNull();
+        });
+      });
+
+      describe('when nextPageIndex is null (we are on the last page of the journey)', () => {
+        it('returns the location of the overview page for the current exercise', () => {
+          rootGetters['exerciseDocument/id'] = 'abc123';
+          getters.nextPageIndex = null;
+          expect(nextPage()).toEqual({
+            name: 'exercise-show-overview',
+            params: { id: 'abc123' },
+          });
+        });
+      });
+
+      describe('when nextPageIndex is not null', () => {
+        it('returns the location of the next edit page in the journey for the current exercise', () => {
+          rootGetters['exerciseDocument/id'] = 'abc123';
+          getters.nextPageIndex = 1;
+          expect(nextPage()).toEqual({
+            name: 'exercise-edit-timeline',
+            params: { id: 'abc123' },
+          });
+        });
+      });
+    });
+  });
 });

--- a/tests/unit/store/exercise/document.spec.js
+++ b/tests/unit/store/exercise/document.spec.js
@@ -144,4 +144,24 @@ describe('store/exercise/single', () => {
       });
     });
   });
+
+  describe('getters', () => {
+    describe('id', () => {
+      it('returns null if no document is loaded', () => {
+        const state = {
+          record: null,
+        };
+        expect(exerciseDocument.getters.id(state)).toBeNull();
+      });
+
+      it('returns the id of the currently loaded document', () => {
+        const state = {
+          record: {
+            id: 'abc123',
+          },
+        };
+        expect(exerciseDocument.getters.id(state)).toBe('abc123');
+      });
+    });
+  });
 });

--- a/tests/unit/views/Exercises/Edit.spec.js
+++ b/tests/unit/views/Exercises/Edit.spec.js
@@ -67,6 +67,31 @@ describe('@/views/Exercises/Edit', () => {
       it('loads the exercise document identified by URL param `id`', () => {
         expect(mockStore.dispatch).toHaveBeenCalledWith('exerciseDocument/bind', 'abc123');
       });
+
+      it('updates `exerciseCreateJourney` with the current route name', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith('exerciseCreateJourney/setCurrentRoute', wrapper.vm.$route.name);
+      });
+    });
+  });
+
+  describe.only('watchers', () => {
+    describe('when $route changes', () => {
+      it('updates `exerciseCreateJourney` with the current route name', () => {
+        // Trigger the $route watcher function
+        const watcher = wrapper.vm.$options.watch.$route;
+        const callWatcher = (newValue, oldValue) => (watcher.call(wrapper.vm, newValue, oldValue));
+
+        // Reset dispatch mock so it doesn't count calls made during mounted()
+        mockStore.dispatch.mockClear();
+
+        callWatcher({ name: 'page-one' });
+        callWatcher({ name: 'page-two' });
+
+        expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+        const calls = mockStore.dispatch.mock.calls;
+        expect(calls[0]).toEqual(['exerciseCreateJourney/setCurrentRoute', 'page-one']);
+        expect(calls[1]).toEqual(['exerciseCreateJourney/setCurrentRoute', 'page-two']);
+      });
     });
   });
 });

--- a/tests/unit/views/Exercises/Edit.spec.js
+++ b/tests/unit/views/Exercises/Edit.spec.js
@@ -1,52 +1,71 @@
 import Edit from '@/views/Exercises/Edit';
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Router from 'vue-router';
-import Vuex from 'vuex';
+import { shallowMount } from '@vue/test-utils';
+import LoadingMessage from '@/components/LoadingMessage';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-localVue.use(Router);
+const mockStore = {
+  dispatch: jest.fn().mockResolvedValue(),
+};
 
-const router = new Router();
-
-const store = new Vuex.Store({
-  dispatch: jest.fn(),
-  modules: {
-    exerciseDocument: {
-      namespaced: true,
-      actions: {
-        bind: () => {
-          new Promise((resolve) => {
-            return resolve();
-          });
-        },
-      },
-    },
+const mockRoute = {
+  name: 'name-of-current-route',
+  params: {
+    id: 'abc123',
   },
-});
+};
 
 const createTestSubject = () => {
   return shallowMount(Edit, {
-    store,
-    localVue,
-    router,
+    mocks: {
+      $store: mockStore,
+      $route: mockRoute,
+    },
+    stubs: {
+      RouterView: true,
+    },
   });
 };
 
 describe('@/views/Exercises/Edit', () => {
+  let wrapper;
+  beforeEach(() => {
+    mockStore.dispatch.mockClear();
+    wrapper = createTestSubject();
+  });
+
   describe('template', () => {
     describe('when loaded is false', () => {
+      beforeEach(() => {
+        wrapper.setData({ loaded: false });
+      });
+
       it('renders LoadingMessage component', () => {
-        let wrapper = createTestSubject();
-        expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(true);
+        expect(wrapper.find(LoadingMessage).exists()).toBe(true);
+      });
+
+      it('does not render the child page', () => {
+        expect(wrapper.find('RouterView-stub').exists()).toBe(false);
       });
     });
 
-     describe('when loaded is true', () => {
-      it('renders LoadingMessage component', () => {
-        let wrapper = createTestSubject();
+    describe('when loaded is true', () => {
+      beforeEach(() => {
         wrapper.setData({ loaded: true });
-        expect(wrapper.find({ ref: 'loadingMessageComponent' }).exists()).toBe(false);
+      });
+
+      it('does not render LoadingMessage component', () => {
+        expect(wrapper.find(LoadingMessage).exists()).toBe(false);
+      });
+
+      it('renders the child page', () => {
+        expect(wrapper.find('RouterView-stub').exists()).toBe(true);
+      });
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    describe('mounted', () => {
+      it('loads the exercise document identified by URL param `id`', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith('exerciseDocument/bind', 'abc123');
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit/Contacts.spec.js
+++ b/tests/unit/views/Exercises/Edit/Contacts.spec.js
@@ -5,11 +5,16 @@ const mockStore = {
   dispatch: jest.fn(),
   state: {
     exerciseDocument: {
-      record: {
-        id: '001',
-      },
+      record: {},
     },
   },
+  getters: {
+    'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+  },
+};
+
+const mockRouter = {
+  push: jest.fn(),
 };
 
 describe('views/Exercises/Edit/Contacts', () => {
@@ -18,6 +23,7 @@ describe('views/Exercises/Edit/Contacts', () => {
     wrapper = shallowMount(ExerciseEditContacts, {
       mocks: {
         $store: mockStore,
+        $router: mockRouter,
       },
     });
   });
@@ -73,6 +79,10 @@ describe('views/Exercises/Edit/Contacts', () => {
       it('with the expected save payload', () => {
         const dispatchedPayload = mockStore.dispatch.mock.calls[0][1];
         expect(dispatchedPayload).toEqual(expect.objectContaining(exerciseData));
+      });
+
+      it('navigates to the next page of the create journey', () => {
+        expect(mockRouter.push).toHaveBeenCalledWith(mockStore.getters['exerciseCreateJourney/nextPage']);
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -5,11 +5,16 @@ const mockStore = {
   dispatch: jest.fn(),
   state: {
     exerciseDocument: {
-      record: {
-        id: '001',
-      },
+      record: {},
     },
   },
+  getters: {
+    'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+  },
+};
+
+const mockRouter = {
+  push: jest.fn(),
 };
 
 describe('views/Exercises/Edit/Eligibility', () => {
@@ -18,6 +23,7 @@ describe('views/Exercises/Edit/Eligibility', () => {
     wrapper = shallowMount(ExerciseEditEligibility, {
       mocks: {
         $store: mockStore,
+        $router: mockRouter,
       },
     });
   });
@@ -73,6 +79,10 @@ describe('views/Exercises/Edit/Eligibility', () => {
       it('with the expected save payload', () => {
         const dispatchedPayload = mockStore.dispatch.mock.calls[0][1];
         expect(dispatchedPayload).toEqual(expect.objectContaining(exerciseData));
+      });
+
+      it('navigates to the next page of the create journey', () => {
+        expect(mockRouter.push).toHaveBeenCalledWith(mockStore.getters['exerciseCreateJourney/nextPage']);
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit/Shortlisting.spec.js
+++ b/tests/unit/views/Exercises/Edit/Shortlisting.spec.js
@@ -5,11 +5,16 @@ const mockStore = {
   dispatch: jest.fn(),
   state: {
     exerciseDocument: {
-      record: {
-        id: '001',
-      },
+      record: {},
     },
   },
+  getters: {
+    'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+  },
+};
+
+const mockRouter = {
+  push: jest.fn(),
 };
 
 describe('views/Exercises/Edit/Shortlisting', () => {
@@ -18,6 +23,7 @@ describe('views/Exercises/Edit/Shortlisting', () => {
     wrapper = shallowMount(ExerciseEditShortlisting, {
       mocks: {
         $store: mockStore,
+        $router: mockRouter,
       },
     });
   });
@@ -73,6 +79,10 @@ describe('views/Exercises/Edit/Shortlisting', () => {
       it('with the expected save payload', () => {
         const dispatchedPayload = mockStore.dispatch.mock.calls[0][1];
         expect(dispatchedPayload).toEqual(expect.objectContaining(exerciseData));
+      });
+
+      it('navigates to the next page of the create journey', () => {
+        expect(mockRouter.push).toHaveBeenCalledWith(mockStore.getters['exerciseCreateJourney/nextPage']);
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit/Timeline.spec.js
+++ b/tests/unit/views/Exercises/Edit/Timeline.spec.js
@@ -5,11 +5,16 @@ const mockStore = {
   dispatch: jest.fn(),
   state: {
     exerciseDocument: {
-      record: {
-        id: '001',
-      },
+      record: {},
     },
   },
+  getters: {
+    'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+  },
+};
+
+const mockRouter = {
+  push: jest.fn(),
 };
 
 describe('views/Exercises/Edit/Timeline', () => {
@@ -18,6 +23,7 @@ describe('views/Exercises/Edit/Timeline', () => {
     wrapper = shallowMount(ExerciseEditTimeline, {
       mocks: {
         $store: mockStore,
+        $router: mockRouter,
       },
     });
   });
@@ -73,6 +79,10 @@ describe('views/Exercises/Edit/Timeline', () => {
       it('with the expected save payload', () => {
         const dispatchedPayload = mockStore.dispatch.mock.calls[0][1];
         expect(dispatchedPayload).toEqual(expect.objectContaining(exerciseData));
+      });
+
+      it('navigates to the next page of the create journey', () => {
+        expect(mockRouter.push).toHaveBeenCalledWith(mockStore.getters['exerciseCreateJourney/nextPage']);
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit/Vacancy.spec.js
+++ b/tests/unit/views/Exercises/Edit/Vacancy.spec.js
@@ -5,11 +5,16 @@ const mockStore = {
   dispatch: jest.fn(),
   state: {
     exerciseDocument: {
-      record: {
-        id: '001',
-      },
+      record: {},
     },
   },
+  getters: {
+    'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+  },
+};
+
+const mockRouter = {
+  push: jest.fn(),
 };
 
 describe('views/Exercises/Edit/Vacancy', () => {
@@ -18,6 +23,7 @@ describe('views/Exercises/Edit/Vacancy', () => {
     wrapper = shallowMount(ExerciseEditVacancy, {
       mocks: {
         $store: mockStore,
+        $router: mockRouter,
       },
     });
   });
@@ -73,6 +79,10 @@ describe('views/Exercises/Edit/Vacancy', () => {
       it('with the expected save payload', () => {
         const dispatchedPayload = mockStore.dispatch.mock.calls[0][1];
         expect(dispatchedPayload).toEqual(expect.objectContaining(exerciseData));
+      });
+
+      it('navigates to the next page of the create journey', () => {
+        expect(mockRouter.push).toHaveBeenCalledWith(mockStore.getters['exerciseCreateJourney/nextPage']);
       });
     });
   });


### PR DESCRIPTION
[Trello card](https://trello.com/c/kgY2pLws/53-implement-the-create-exercise-journey-functionality)

This PR adds functionality to power the 'Create an exercise' journey. From the 'Create an exercise' page (`/exercises/new`), the user creates a new exercise and can choose which additional information they want to add in the session.

The 'Save and continue' button at the bottom of each page will progressively save to the database and walk the user through their chosen journey.

At the end of the journey, or if the user chooses not to enter further information, they will be taken to the exercise overview page.

### Implementation

The journey navigation functionality is implemented as a Vuex module called `exerciseCreateJourney`. This is responsible for holding and managing the state of the user's chosen journey.

The journey is set by dispatching action:
```js
this.$store.dispatch('exerciseCreateJourney/start', [])
```

Where the dispatch payload is an array of pages to include in the journey. These can be any combination of:

```js
[
  'contacts',
  'shortlisting',
  'timeline',
  'vacancy',
  'eligibility',
]
```

Whilst the array of selected pages can be provided in any order, the user will always be walked through the journey in the order listed above.

The next page to navigate to is always available from the getter:
```js
this.$store.getters['exerciseCreateJourney/nextPage']
```

### New getter on `exerciseDocument` Vuex module

This PR also adds a new getter to the `exerciseDocument` Vuex module, which is what holds the currently loaded exercise record:
```js
this.$store.getters['exerciseDocument/id']
```

This will either be `null` when no record is bound, or it'll be the ID of the document.