### PR TITLE
Add links to exercise dashboard page

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -30,11 +30,15 @@
             :key="exercise.id"
             class="govuk-summary-list__row"
           >
-            <dt class="govuk-summary-list__key-narrow">
-              <a href="detail">{{ exercise.reference }}</a>
+            <dt class="govuk-summary-list__key govuk-summary-list__key-narrow">
+              <RouterLink :to="{ name: 'exercise-show-overview', params: { id: exercise.id } }">
+                118
+              </RouterLink>
             </dt>
             <dd class="govuk-summary-list__value">
-              <a href="detail">{{ exercise.name }}</a>
+              <RouterLink :to="{ name: 'exercise-show-overview', params: { id: exercise.id } }">
+                {{ exercise.name }}
+              </RouterLink>
             </dd>
           </div>
         </dl>


### PR DESCRIPTION
[Trello card](https://trello.com/c/Jxb3cXLN/120-link-to-the-exercise-overview-page-from-the-dashboard)

- Exercise names on the dashboard page now link to the exercise overview page
- I fixed a styling bug with the narrow summary list key (the `.govuk-summary-list__key` class was missing)
- I've hardcoded the reference number to be '118' – this makes the page consistent with the exercise show page, which also has a hardcoded reference number. We know that auto-generated reference numbers are still to be developed, but it looks odd without any reference number displayed on the dashboard.