### PR TITLE
Add getter to get clone of the state object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4125,9 +4125,9 @@
       }
     },
     "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-deep": {
@@ -5380,6 +5380,14 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        }
       }
     },
     "define-properties": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
+    "clone": "^2.1.2",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.0.0",
     "firebase-mock": "^2.2.10",

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -1,6 +1,7 @@
 import { firestore } from '@/firebase';
 import { firestoreAction } from 'vuexfire';
 import vuexfireSerialize from '@/helpers/vuexfireSerialize';
+import clone from 'clone';
 
 const collection = firestore.collection('exercises');
 
@@ -31,6 +32,9 @@ export default {
     id: (state) => {
       if (state.record === null) return null;
       return state.record.id;
+    },
+    exerciseData: (state) => () => {
+      return clone(state.record);
     },
   },
 };

--- a/src/store/exercise/document.js
+++ b/src/store/exercise/document.js
@@ -33,7 +33,7 @@ export default {
       if (state.record === null) return null;
       return state.record.id;
     },
-    exerciseData: (state) => () => {
+    data: (state) => () => {
       return clone(state.record);
     },
   },

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -152,7 +152,7 @@ export default {
     RepeatableFields,
   },
   data(){
-    const exercise = this.$store.getters['exerciseDocument/exerciseData']();
+    const exercise = this.$store.getters['exerciseDocument/data']();
 
     return {
       repeatableFields: {

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -152,7 +152,7 @@ export default {
     RepeatableFields,
   },
   data(){
-    const exercise = this.$store.state.exerciseDocument.record;
+    const exercise = this.$store.getters['exerciseDocument/exerciseData']();
 
     return {
       repeatableFields: {

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -180,7 +180,7 @@ export default {
     TextField,
   },
   data(){
-    const exercise = this.$store.state.exerciseDocument.record;
+    const exercise = this.$store.getters['exerciseDocument/data']();
 
     return {
       exercise: {

--- a/src/views/Exercises/Edit/Shortlisting.vue
+++ b/src/views/Exercises/Edit/Shortlisting.vue
@@ -77,7 +77,7 @@ export default {
     RepeatableFields,
   },
   data(){
-    const exercise = this.$store.state.exerciseDocument.record;
+    const exercise = this.$store.getters['exerciseDocument/data']();
 
     return {
       repeatableFields: {

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -166,7 +166,7 @@ export default {
     RepeatableFields,
   },
   data(){
-    const exercise = this.$store.state.exerciseDocument.record;
+    const exercise = this.$store.getters['exerciseDocument/data']();
 
     return {
       repeatableFields: {

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -315,7 +315,7 @@ export default {
     Currency,
   },
   data(){
-    const exercise = this.$store.state.exerciseDocument.record;
+    const exercise = this.$store.getters['exerciseDocument/data']();
 
     return {
       exercise: {

--- a/src/views/Exercises/Show/Contacts.vue
+++ b/src/views/Exercises/Show/Contacts.vue
@@ -150,7 +150,7 @@
 export default {
   computed: {
     exercise() {
-      return this.$store.state.exerciseDocument.record;
+      return this.$store.getters['exerciseDocument/data']();
     },
   },
 };

--- a/src/views/Exercises/Show/Overview.vue
+++ b/src/views/Exercises/Show/Overview.vue
@@ -65,7 +65,7 @@ export default {
   },
   computed: {
     exercise() {
-      return this.$store.state.exerciseDocument.record;
+      return this.$store.getters['exerciseDocument/data']();
     },
     timeline() {
       return [

--- a/src/views/Exercises/Show/Shortlisting.vue
+++ b/src/views/Exercises/Show/Shortlisting.vue
@@ -35,7 +35,7 @@
 export default {
   computed: {
     exercise() {
-      return this.$store.state.exerciseDocument.record;
+      return this.$store.getters['exerciseDocument/data']();
     },
     methods() {
       const methods = this.exercise.shortlistingMethods;

--- a/src/views/Exercises/Show/Timeline.vue
+++ b/src/views/Exercises/Show/Timeline.vue
@@ -26,7 +26,7 @@ export default {
   },
   computed: {
     exercise() {
-      return this.$store.state.exerciseDocument.record;
+      return this.$store.getters['exerciseDocument/data']();
     },
     timeline() {
       return [

--- a/src/views/Exercises/Show/Vacancy.vue
+++ b/src/views/Exercises/Show/Vacancy.vue
@@ -140,7 +140,7 @@
 export default {
   computed: {
     exercise() {
-      return this.$store.state.exerciseDocument.record;
+      return this.$store.getters['exerciseDocument/data']();
     },
   },
 };

--- a/tests/unit/store/exercise/document.spec.js
+++ b/tests/unit/store/exercise/document.spec.js
@@ -163,5 +163,28 @@ describe('store/exercise/single', () => {
         expect(exerciseDocument.getters.id(state)).toBe('abc123');
       });
     });
+
+    describe('exerciseData', () => {
+      it('returns a function', () => {
+        const state = {
+          record: {},
+        };
+        expect(exerciseDocument.getters.exerciseData(state)).toBeFunction();
+      });
+
+      it('returns a clone of the record data (rather than a reference to the state object)', () => {
+        const state = {
+          record: {
+            futureStart: 123, 
+            hmctsWelshGovLead: 'Test Name',
+            name: 'Test Name',
+          },
+        };
+
+        const recordObject = exerciseDocument.getters.exerciseData(state)();
+        expect(recordObject).not.toBe(state.record);
+        expect(recordObject).toEqual(state.record);
+      });
+    });
   });
 });

--- a/tests/unit/store/exercise/document.spec.js
+++ b/tests/unit/store/exercise/document.spec.js
@@ -164,12 +164,12 @@ describe('store/exercise/single', () => {
       });
     });
 
-    describe('exerciseData', () => {
+    describe('data()', () => {
       it('returns a function', () => {
         const state = {
           record: {},
         };
-        expect(exerciseDocument.getters.exerciseData(state)).toBeFunction();
+        expect(exerciseDocument.getters.data(state)).toBeFunction();
       });
 
       it('returns a clone of the record data (rather than a reference to the state object)', () => {
@@ -181,7 +181,7 @@ describe('store/exercise/single', () => {
           },
         };
 
-        const recordObject = exerciseDocument.getters.exerciseData(state)();
+        const recordObject = exerciseDocument.getters.data(state)();
         expect(recordObject).not.toBe(state.record);
         expect(recordObject).toEqual(state.record);
       });

--- a/tests/unit/views/Exercises/Edit/Contacts.spec.js
+++ b/tests/unit/views/Exercises/Edit/Contacts.spec.js
@@ -1,6 +1,10 @@
 import ExerciseEditContacts from '@/views/Exercises/Edit/Contacts';
 import { shallowMount } from '@vue/test-utils';
 
+const exercise = {
+  exerciseMailbox: 'test@jac.co.uk',
+};
+
 const mockStore = {
   dispatch: jest.fn(),
   state: {
@@ -10,6 +14,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+    'exerciseDocument/exerciseData': () => () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Contacts.spec.js
+++ b/tests/unit/views/Exercises/Edit/Contacts.spec.js
@@ -14,7 +14,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
-    'exerciseDocument/exerciseData': () => () => exercise,
+    'exerciseDocument/exerciseData': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Contacts.spec.js
+++ b/tests/unit/views/Exercises/Edit/Contacts.spec.js
@@ -14,7 +14,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
-    'exerciseDocument/exerciseData': () => exercise,
+    'exerciseDocument/data': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -1,6 +1,10 @@
 import ExerciseEditEligibility from '@/views/Exercises/Edit/Eligibility';
 import { shallowMount } from '@vue/test-utils';
 
+const exercise = {
+  retirementAge: '70',
+};
+
 const mockStore = {
   dispatch: jest.fn(),
   state: {
@@ -10,6 +14,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+    'exerciseDocument/data': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Shortlisting.spec.js
+++ b/tests/unit/views/Exercises/Edit/Shortlisting.spec.js
@@ -1,6 +1,11 @@
 import ExerciseEditShortlisting from '@/views/Exercises/Edit/Shortlisting';
 import { shallowMount } from '@vue/test-utils';
 
+const exercise = {
+  shortlistingMethods: null,
+  otherShortlistingMethod: null,
+};
+
 const mockStore = {
   dispatch: jest.fn(),
   state: {
@@ -10,6 +15,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+    'exerciseDocument/data': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Timeline.spec.js
+++ b/tests/unit/views/Exercises/Edit/Timeline.spec.js
@@ -1,6 +1,11 @@
 import ExerciseEditTimeline from '@/views/Exercises/Edit/Timeline';
 import { shallowMount } from '@vue/test-utils';
 
+const exercise = {
+  applicationOpenDate: new Date(2019, 1, 1),
+  applicationCloseDate: new Date(2019, 3, 3),
+};
+
 const mockStore = {
   dispatch: jest.fn(),
   state: {
@@ -10,6 +15,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+    'exerciseDocument/data': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Edit/Vacancy.spec.js
+++ b/tests/unit/views/Exercises/Edit/Vacancy.spec.js
@@ -1,6 +1,11 @@
 import ExerciseEditVacancy from '@/views/Exercises/Edit/Vacancy';
 import { shallowMount } from '@vue/test-utils';
 
+const exercise = {
+  typeOfExercise: 'legal',
+  isCourtOrTribunal: 'court',
+};
+
 const mockStore = {
   dispatch: jest.fn(),
   state: {
@@ -10,6 +15,7 @@ const mockStore = {
   },
   getters: {
     'exerciseCreateJourney/nextPage': { name: 'mock-next-page' },
+    'exerciseDocument/data': () => exercise,
   },
 };
 

--- a/tests/unit/views/Exercises/Show/Contacts.spec.js
+++ b/tests/unit/views/Exercises/Show/Contacts.spec.js
@@ -18,6 +18,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });

--- a/tests/unit/views/Exercises/Show/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Show/Eligibility.spec.js
@@ -27,6 +27,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });

--- a/tests/unit/views/Exercises/Show/Overview.spec.js
+++ b/tests/unit/views/Exercises/Show/Overview.spec.js
@@ -19,6 +19,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });

--- a/tests/unit/views/Exercises/Show/Shortlisting.spec.js
+++ b/tests/unit/views/Exercises/Show/Shortlisting.spec.js
@@ -18,6 +18,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });

--- a/tests/unit/views/Exercises/Show/Timeline.spec.js
+++ b/tests/unit/views/Exercises/Show/Timeline.spec.js
@@ -33,6 +33,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });

--- a/tests/unit/views/Exercises/Show/Vacancy.spec.js
+++ b/tests/unit/views/Exercises/Show/Vacancy.spec.js
@@ -18,6 +18,9 @@ const store = new Vuex.Store({
       state: {
         record: exercise,
       },
+      getters: {
+        data: () => () => exercise,
+      },
     },
   },
 });


### PR DESCRIPTION
**Change log:**

To prevent modifying a record in the state we've added new getter that returns a clone of the state instead of an actual state object.

This change is implemented for add Edit and Show pages