### PR TITLE
Refactor router tests

### DIFF
--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -3,6 +3,22 @@ import App from '@/App';
 import Router from 'vue-router';
 import Vuex from 'vuex';
 
+const exerciseRoutes = [
+  ['exercise-new', 'Create An Exercise'],
+  ['exercise-show-overview', 'Exercise Details | Overview'],
+  ['exercise-show-applications', 'Exercise Details | Applications'],
+  ['exercise-show-contacts', 'Exercise Details | Contacts'],
+  ['exercise-show-timeline', 'Exercise Details | Timeline'],
+  ['exercise-show-shortlisting', 'Exercise Details | Shortlisting'],
+  ['exercise-show-vacancy', 'Exercise Details | Vacancy information'],
+  ['exercise-show-eligibility', 'Exercise Details | Eligibility information'],
+  ['exercise-edit-contacts', 'Add Exercise Contacts'],
+  ['exercise-edit-shortlisting', 'Add Shortlisting Methods'],
+  ['exercise-edit-timeline', 'Add Exercise Timeline'],
+  ['exercise-edit-eligibility', 'Add Eligibility Information'],
+  ['exercise-edit-vacancy', 'About The Vacancy'],
+];
+
 describe('Page titles', () => {
   let router;
   let store;
@@ -27,138 +43,43 @@ describe('Page titles', () => {
     email: 'user@judicialappointments.digital',
   };
 
-  describe('Sign In page', () => {
-
+  describe('sign in', () => {
     beforeEach(() => {
-      store.dispatch('setCurrentUser', null);
+      router.push({ name: 'sign-in' });
     });
 
-    it('sets title as Sign In', () => {
-      router.push('/sign-in');
+    it('contains Sign In', () => {
       expect(document.title).toContain('Sign In');
     });
 
     it('contains Judicial Appointments Commission', () => {
-      router.push('/sign-in');
       expect(document.title).toContain('Judicial Appointments Commission');
     });
   });
 
-  describe('Dashboard Page', () => {
-
+  describe('dashboard', () => {
     beforeEach(() => {
       store.dispatch('setCurrentUser', user);
+      router.push({ name: 'dashboard' });
     });
 
-    it('sets title as Dashboard', () => {
-      router.push('/dashboard');
+    it('contains Dashboard', () => {
       expect(document.title).toContain('Dashboard');
     });
 
     it('contains Judicial Appointments Commission', () => {
-      router.push('/dashboard');
       expect(document.title).toContain('Judicial Appointments Commission');
     });
   });
 
-  describe('/exercises/new', () => {
-    beforeEach(() => {
+  describe.each(exerciseRoutes)('%s', (routeName, routeTitle) => {
+     beforeEach(() => {
       store.dispatch('setCurrentUser', user);
-      router.push('/exercises/new');
+      router.push({ name: routeName, params: { id: 123 } });
     });
 
-    it('sets title as Create An Exercise', () => {
-      expect(document.title).toContain('Create An Exercise');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id/edit/contacts', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123/edit/contacts');
-    });
-
-    it('sets title as Add Exercise Contacts', () => {
-      expect(document.title).toContain('Add Exercise Contacts');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id/edit/shortlisting', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123/edit/shortlisting');
-    });
-
-    it('sets title as Add Shortlisting Methods', () => {
-      expect(document.title).toContain('Add Shortlisting Methods');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id/edit/timeline', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123/edit/timeline');
-    });
-
-    it('sets title as Add Exercise Timeline', () => {
-      expect(document.title).toContain('Add Exercise Timeline');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id/edit/eligibility', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123/edit/eligibility');
-    });
-
-    it('sets title as Add Eligibility Information', () => {
-      expect(document.title).toContain('Add Eligibility Information');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id/edit/vacancy', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123/edit/vacancy');
-    });
-
-    it('sets title as About The Vacancy', () => {
-      expect(document.title).toContain('About The Vacancy');
-    });
-
-    it('contains Judicial Appointments Commission', () => {
-      expect(document.title).toContain('Judicial Appointments Commission');
-    });
-  });
-
-  describe('/exercises/:id', () => {
-    beforeEach(() => {
-      store.dispatch('setCurrentUser', user);
-      router.push('/exercises/abc123');
-    });
-
-    it('sets title as Exercise Details | Overview', () => {
-      expect(document.title).toContain('Exercise Details | Overview');
+    it(`contains ${routeTitle}`, () => {
+      expect(document.title).toContain(routeTitle);
     });
 
     it('contains Judicial Appointments Commission', () => {

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -3,6 +3,23 @@ import App from '@/App';
 import Router from 'vue-router';
 import Vuex from 'vuex';
 
+const id = 12345;
+const routes = [
+  ['exercise-new', '/exercises/new'],
+  ['exercise-show-overview', `/exercises/${id}/`],
+  ['exercise-show-applications', `/exercises/${id}/applications`],
+  ['exercise-show-contacts', `/exercises/${id}/contacts`],
+  ['exercise-show-timeline', `/exercises/${id}/timeline`],
+  ['exercise-show-shortlisting', `/exercises/${id}/shortlisting`],
+  ['exercise-show-vacancy', `/exercises/${id}/vacancy`],
+  ['exercise-show-eligibility', `/exercises/${id}/eligibility`],
+  ['exercise-edit-contacts', `/exercises/${id}/edit/contacts`],
+  ['exercise-edit-shortlisting', `/exercises/${id}/edit/shortlisting`],
+  ['exercise-edit-timeline', `/exercises/${id}/edit/timeline`],
+  ['exercise-edit-eligibility', `/exercises/${id}/edit/eligibility`],
+  ['exercise-edit-vacancy', `/exercises/${id}/edit/vacancy`],
+];
+
 describe('Sign in journey', () => {
   let subject;
   let router;
@@ -29,65 +46,22 @@ describe('Sign in journey', () => {
   };
 
   describe('for unauthenticated user', () => {
-    describe('when they visit /dashboard', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/');
+    describe('when they visit page sign in', () => {
+      it('loads sign in page', () => {
+        router.push({ name: 'sign-in' });
         expect(subject.vm.$route.path).toBe('/sign-in');
       });
     });
 
-    describe('when they visit /exercises/new', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/new');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/contacts', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123/edit/contacts');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/shortlisting', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123/edit/shortlisting');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/timeline', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123/edit/timeline');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/eligibility', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123/edit/eligibility');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/vacancy', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123/edit/vacancy');
-        expect(subject.vm.$route.path).toBe('/sign-in');
-      });
-    });
-
-    describe('when they visit /exercises/:id', () => {
-      it('redirects to /sign-in page', () => {
-        router.push('/exercises/abc123');
+    describe.each(routes)('when they visit page %s', (routeName) => {
+      it('loads sign in page',() => {
+        router.push({ name: routeName, params: { id } });
         expect(subject.vm.$route.path).toBe('/sign-in');
       });
     });
   });
 
   describe('for authenticated user', () => {
-
     beforeEach(() => {
       store.dispatch('setCurrentUser', user);
     });
@@ -99,66 +73,17 @@ describe('Sign in journey', () => {
       });
     });
 
-    describe('when going to sign-in page', () => {
-      it('redirects to the dashboard page', () => {
-        router.push('/sign-in');
+    describe('when they visit page sign in', () => {
+      it("redirects to the dashboard page'", () => {
+        router.push({ name: 'sign-in' });
         expect(subject.vm.$route.path).toBe('/dashboard');
       });
     });
 
-    describe('when going to the dashboard page', () => {
-      it('can access the dashboard page', () => {
-        router.push('/dashboard');
-        expect(subject.vm.$route.path).toBe('/dashboard');
-      });
-    });
-
-    describe('when they visit /exercises/new', () => {
-      it('loads the page', () => {
-        router.push('/exercises/new');
-        expect(subject.vm.$route.path).toBe('/exercises/new');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/contacts', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123/edit/contacts');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123/edit/contacts');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/shortlisting', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123/edit/shortlisting');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123/edit/shortlisting');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/timeline', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123/edit/timeline');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123/edit/timeline');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/eligibility', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123/edit/eligibility');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123/edit/eligibility');
-      });
-    });
-
-    describe('when they visit /exercises/:id/edit/vacancy', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123/edit/vacancy');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123/edit/vacancy');
-      });
-    });
-
-    describe('when they visit /exercises/:id', () => {
-      it('loads the page', () => {
-        router.push('/exercises/abc123');
-        expect(subject.vm.$route.path).toBe('/exercises/abc123');
+    describe.each(routes)('when they visit page %s', (routeName, routePath) => {
+      it(`loads ${routePath}`,() => {
+        router.push({ name: routeName, params: { id } });
+        expect(subject.vm.$route.path).toBe(routePath);
       });
     });
   });


### PR DESCRIPTION
We've made router test files smaller and more readable by using `each` method and looping through the list of pages instead of writing tests for every route separately.

**Changelog:**

Refactor page-tiles and sign in journey specs
