### PR TITLE
Amended the Eligibility Show page to include 'Additional skills' field

### DIFF
--- a/src/views/Exercises/Show/Eligibility.vue
+++ b/src/views/Exercises/Show/Eligibility.vue
@@ -81,7 +81,14 @@
         <dt class="govuk-summary-list__key">
           Additional skills and experience
         </dt>
-        <dd class="govuk-summary-list__value" />
+        <dd class="govuk-summary-list__value">
+          <span v-if="exercise.aSCApply === true">
+            {{ exercise.yesASCApply }}
+          </span>
+          <span v-else>
+            Null
+          </span>
+        </dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
In the previous PR, I added the missing conditional reveal TextareaInput component, under the Does ASC apply radios, into the Eligibility Edit page. This PR amends the Eligibility Show page to display the data entered into this TextareaInput component. 

- Added a V-if to display the data in the conditional reveal Textarea 
field under the 'Does ASC apply' radio. 

- Code has been linted.

- tests are passing.

🍁 