### PR TITLE
Bugfix: save unanswered boolean fields

### DIFF
--- a/src/helpers/booleanOrNull.js
+++ b/src/helpers/booleanOrNull.js
@@ -1,0 +1,4 @@
+export default (value) => {
+  if (typeof value === 'boolean') return value;
+  return null;
+};

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -179,6 +179,7 @@ import CheckboxGroup from '@/components/Form/CheckboxGroup';
 import CheckboxItem from '@/components/Form/CheckboxItem';
 import TextField from '@/components/Form/TextField';
 import TextareaInput from '@/components/Form/TextareaInput';
+import booleanOrNull from '@/helpers/booleanOrNull';
 
 export default {
   components: {
@@ -196,10 +197,10 @@ export default {
       exercise: {
         postQualificationExperience: exercise.postQualificationExperience || null,
         otherYears: exercise.otherYears || null,
-        schedule2DApply: exercise.schedule2DApply || null,
+        schedule2DApply: booleanOrNull(exercise.schedule2DApply),
         qualifications: exercise.qualifications || null,
         otherQualifications: exercise.otherQualifications || null,
-        aSCApply: exercise.aSCApply || null,
+        aSCApply: booleanOrNull(exercise.aSCApply),
         yesASCApply: exercise.yesASCApply || null,
         reasonableLengthService: exercise.reasonableLengthService || null,
         otherLOS: exercise.otherLOS || null,

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -131,7 +131,7 @@
           label="Is salaried part-time working (SPTW) offered?"
         >
           <RadioItem
-            value="true"
+            :value="true"
             label="Yes"
           >
             <TextareaInput
@@ -141,7 +141,7 @@
             />
           </RadioItem>
           <RadioItem
-            value="no"
+            :value="false"
             label="No"
           >
             <TextareaInput
@@ -257,6 +257,7 @@ import CheckboxGroup from '@/components/Form/CheckboxGroup';
 import CheckboxItem from '@/components/Form/CheckboxItem';
 import Currency from '@/components/Form/Currency';
 import TextareaInput from '@/components/Form/TextareaInput';
+import booleanOrNull from '@/helpers/booleanOrNull';
 
 export default {
   components: {
@@ -277,7 +278,7 @@ export default {
         isCourtOrTribunal: exercise.isCourtOrTribunal || [],
         appointmentType: exercise.appointmentType || [],
         feePaidFee: exercise.feePaidFee || null,
-        isSPTWOffered: exercise.isSPTWOffered || [],
+        isSPTWOffered: booleanOrNull(exercise.isSPTWOffered),
         yesSalaryDetails: exercise.yesSalaryDetails || null,
         noSalaryDetails: exercise.noSalaryDetails || null,
         immediateStart: exercise.immediateStart || null,

--- a/tests/unit/helpers/booleanOrNull.spec.js
+++ b/tests/unit/helpers/booleanOrNull.spec.js
@@ -1,0 +1,32 @@
+import booleanOrNull from '@/helpers/booleanOrNull';
+
+describe('@/helpers/booleanOrNull', () => {
+  it('is a function', () => {
+    expect(booleanOrNull).toBeInstanceOf(Function);
+  });
+
+  describe('when input value is boolean `true`', () => {
+    it('returns boolean `true`', () => {
+      expect(booleanOrNull(true)).toBe(true);
+    });
+  });
+
+  describe('when input value is boolean `false`', () => {
+    it('returns boolean `false`', () => {
+      expect(booleanOrNull(false)).toBe(false);
+    });
+  });
+
+  describe('when input value is not a boolean', () => {
+    it('returns `null`', () => {
+      expect(booleanOrNull('a string value')).toBeNull();
+      expect(booleanOrNull('true')).toBeNull();
+      expect(booleanOrNull('false')).toBeNull();
+      expect(booleanOrNull(1)).toBeNull();
+      expect(booleanOrNull(0)).toBeNull();
+      expect(booleanOrNull(-1)).toBeNull();
+      expect(booleanOrNull({})).toBeNull();
+      expect(booleanOrNull(new Date())).toBeNull();
+    });
+  });
+});

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -22,15 +22,19 @@ const mockRouter = {
   push: jest.fn(),
 };
 
+const createTestSubject = () => {
+  return shallowMount(ExerciseEditEligibility, {
+    mocks: {
+      $store: mockStore,
+      $router: mockRouter,
+    },
+  });
+};
+
 describe('views/Exercises/Edit/Eligibility', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallowMount(ExerciseEditEligibility, {
-      mocks: {
-        $store: mockStore,
-        $router: mockRouter,
-      },
-    });
+    wrapper = createTestSubject();
   });
 
   describe('template', () => {
@@ -57,6 +61,46 @@ describe('views/Exercises/Edit/Eligibility', () => {
       const button = wrapper.find('form button');
       expect(button.element.type).toBe('submit');
       expect(button.text()).toBe('Save and continue');
+    });
+  });
+
+  describe('data', () => {
+    const booleanFields = [
+      'schedule2DApply',
+      'aSCApply',
+    ];
+    describe.each(booleanFields)('exercise.%s', (fieldName) => {
+      let originalValue;
+      beforeEach(() => {
+        originalValue = exercise[fieldName];
+      });
+      afterEach(() => {
+        exercise[fieldName] = originalValue;
+      });
+
+      describe(`when database value for "${fieldName}" is undefined`, () => {
+        it('defaults to `null`', () => {
+          exercise[fieldName] = undefined;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBeNull();
+        });
+      });
+
+      describe(`when database value for "${fieldName}" is boolean true`, () => {
+        it('is `true`', () => {
+          exercise[fieldName] = true;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBe(true);
+        });
+      });
+
+      describe(`when database value for "${fieldName}" is boolean false`, () => {
+        it('is `false`', () => {
+          exercise[fieldName] = false;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBe(false);
+        });
+      });
     });
   });
 

--- a/tests/unit/views/Exercises/Edit/Vacancy.spec.js
+++ b/tests/unit/views/Exercises/Edit/Vacancy.spec.js
@@ -23,15 +23,19 @@ const mockRouter = {
   push: jest.fn(),
 };
 
+const createTestSubject = () => {
+  return shallowMount(ExerciseEditVacancy, {
+    mocks: {
+      $store: mockStore,
+      $router: mockRouter,
+    },
+  });
+};
+
 describe('views/Exercises/Edit/Vacancy', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallowMount(ExerciseEditVacancy, {
-      mocks: {
-        $store: mockStore,
-        $router: mockRouter,
-      },
-    });
+    wrapper = createTestSubject();
   });
 
   describe('template', () => {
@@ -58,6 +62,45 @@ describe('views/Exercises/Edit/Vacancy', () => {
       const button = wrapper.find('form button');
       expect(button.element.type).toBe('submit');
       expect(button.text()).toBe('Save and continue');
+    });
+  });
+
+  describe('data', () => {
+    const booleanFields = [
+      'isSPTWOffered',
+    ];
+    describe.each(booleanFields)('exercise.%s', (fieldName) => {
+      let originalValue;
+      beforeEach(() => {
+        originalValue = exercise[fieldName];
+      });
+      afterEach(() => {
+        exercise[fieldName] = originalValue;
+      });
+
+      describe(`when database value for "${fieldName}" is undefined`, () => {
+        it('defaults to `null`', () => {
+          exercise[fieldName] = undefined;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBeNull();
+        });
+      });
+
+      describe(`when database value for "${fieldName}" is boolean true`, () => {
+        it('is `true`', () => {
+          exercise[fieldName] = true;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBe(true);
+        });
+      });
+
+      describe(`when database value for "${fieldName}" is boolean false`, () => {
+        it('is `false`', () => {
+          exercise[fieldName] = false;
+          wrapper = createTestSubject();
+          expect(wrapper.vm.exercise[fieldName]).toBe(false);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/A0GV0nrk/127-bugfix-unanswered-fields-cause-save-error-because-unsupported-field-value-undefined-on-firestore-update)

When saving a page which contained a boolean input:

- We can't auto-cast falsy field values to `null`, because boolean inputs might be `false`
- But we have to cast unanswered boolean fields to `null` because `undefined` is an invalid field type for Firestore
- I've included unit tests to assert that boolean fields are treated this way

Additionally:

- I updated the "Yes/No" question on the "Vacancy details" page to be a boolean value. I'm fairly sure this [closes a different Trello card](https://trello.com/c/4LGQMCuC/126-change-yes-no-edit-pages-fields-to-be-booleans) too.