### PR TITLE
Create error pages

### DIFF
--- a/src/components/LoadingMessage.vue
+++ b/src/components/LoadingMessage.vue
@@ -14,6 +14,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1>Something went wrong</h1>
+          <p>Reload the page and try again</p>
         </div>
       </div>
     </div>

--- a/src/components/LoadingMessage.vue
+++ b/src/components/LoadingMessage.vue
@@ -13,7 +13,7 @@
     >
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <slot name="failedLoadMessage" />
+          <h1>Something went wrong</h1>
         </div>
       </div>
     </div>

--- a/src/components/LoadingMessage.vue
+++ b/src/components/LoadingMessage.vue
@@ -11,7 +11,11 @@
       v-else
       ref="errorMessage"
     >
-      <p>Could not load data. Please reload the page and try again.</p>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <slot name="failedLoadMessage" />
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/router.js
+++ b/src/router.js
@@ -181,7 +181,7 @@ const router = new Router({
       ],
     },
     {
-      path: '/exercise-not-found',
+      path: '/errors/exercise-not-found',
       name: 'exercise-not-found',
       component: ExerciseNotFound,
       meta: {
@@ -190,12 +190,12 @@ const router = new Router({
       },
     },
     {
-      path: '/page-not-found',
+      path: '/errors/page-not-found',
       name: 'page-not-found',
       component: PageNotFound,
       meta: {
         requiresAuth: true,
-        title: 'Page Not found',
+        title: 'Page Not Found',
       },
     },
     {

--- a/src/router.js
+++ b/src/router.js
@@ -21,6 +21,10 @@ import ExerciseShowShortlisting from '@/views/Exercises/Show/Shortlisting';
 import ExerciseShowVacancy from '@/views/Exercises/Show/Vacancy';
 import ExerciseShowEligibility from '@/views/Exercises/Show/Eligibility';
 
+// Error pages
+import ExerciseNotFound from '@/views/Errors/ExerciseNotFound';
+import PageNotFound from '@/views/Errors/PageNotFound';
+
 import Dashboard from '@/views/Dashboard';
 import SignIn from '@/views/SignIn';
 
@@ -175,6 +179,24 @@ const router = new Router({
           },
         },
       ],
+    },
+    {
+      path: '/exercise-not-found',
+      name: 'exercise-not-found',
+      component: ExerciseNotFound,
+      meta: {
+        requiresAuth: true,
+        title: 'Exercise Not Found',
+      },
+    },
+    {
+      path: '/page-not-found',
+      name: 'page-not-found',
+      component: PageNotFound,
+      meta: {
+        requiresAuth: true,
+        title: 'Page Not found',
+      },
     },
     {
       path: '/sign-in',

--- a/src/views/Errors/ExerciseNotFound.vue
+++ b/src/views/Errors/ExerciseNotFound.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Exercise not found
+      </h1>
+      <p class="govuk-body">
+        There is not an exercise associated with this link address.
+      </p>
+      <p class="govuk-body">
+        You could check:
+        <ul>
+          <li>
+            you've copied and pasted the entire link address
+          </li>
+          <li>there are no obvious misspellings</li>
+        </ul>
+      </p>
+      <p class="govuk-body">
+        If your link still does not work, try searching for the exercise by name.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>

--- a/src/views/Errors/PageNotFound.vue
+++ b/src/views/Errors/PageNotFound.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Page not found
+      </h1>
+      <p class="govuk-body">
+        If you typed the web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -45,8 +45,8 @@ export default {
   },
   methods: {
     redirectToErrorPage() {
-      this.$router.replace({ name: 'exercise-not-found' })
-    }
-  }
+      this.$router.replace({ name: 'exercise-not-found' });
+    },
+  },
 };
 </script>

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -3,7 +3,27 @@
     <LoadingMessage
       v-if="loaded === false"
       :load-failed="loadFailed"
-    />
+    >
+      <template v-slot:failedLoadMessage>
+        <h1 class="govuk-heading-xl">
+          Page not found
+        </h1>
+        <p class="govuk-body">
+          If you typed the web address, check it is correct.
+        </p>
+        <p class="govuk-body">
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p class="govuk-body">
+          Come back to Dashboard page: 
+          <router-link
+            to="/dashboard"
+          >
+            Go to Dashboard
+          </router-link>
+        </p>
+      </template>
+    </LoadingMessage>
     <RouterView v-else />
   </div>
 </template>
@@ -29,8 +49,13 @@ export default {
     const id = this.$route.params.id;
     
     this.$store.dispatch('exerciseDocument/bind', id)
-      .then(() => {
-        this.loaded = true;
+      .then((data) => {
+        if(!(data === null)) {
+          this.loaded = true;
+        }
+        else {
+          this.loadFailed = true;
+        }
       }).catch((e) => {
         this.loadFailed = true;
         throw e;

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -30,11 +30,11 @@ export default {
     
     this.$store.dispatch('exerciseDocument/bind', id)
       .then((data) => {
-        if(!(data === null)) {
-          this.loaded = true;
+        if(data === null) {
+          this.redirectToErrorPage();
         }
         else {
-          this.redirectToErrorPage();
+          this.loaded = true;
         }
       }).catch((e) => {
         this.loadFailed = true;

--- a/src/views/Exercises/Edit.vue
+++ b/src/views/Exercises/Edit.vue
@@ -3,27 +3,7 @@
     <LoadingMessage
       v-if="loaded === false"
       :load-failed="loadFailed"
-    >
-      <template v-slot:failedLoadMessage>
-        <h1 class="govuk-heading-xl">
-          Page not found
-        </h1>
-        <p class="govuk-body">
-          If you typed the web address, check it is correct.
-        </p>
-        <p class="govuk-body">
-          If you pasted the web address, check you copied the entire address.
-        </p>
-        <p class="govuk-body">
-          Come back to Dashboard page: 
-          <router-link
-            to="/dashboard"
-          >
-            Go to Dashboard
-          </router-link>
-        </p>
-      </template>
-    </LoadingMessage>
+    />
     <RouterView v-else />
   </div>
 </template>
@@ -54,7 +34,7 @@ export default {
           this.loaded = true;
         }
         else {
-          this.loadFailed = true;
+          this.redirectToErrorPage();
         }
       }).catch((e) => {
         this.loadFailed = true;
@@ -63,5 +43,10 @@ export default {
 
     this.$store.dispatch('exerciseCreateJourney/setCurrentRoute', this.$route.name);
   },
+  methods: {
+    redirectToErrorPage() {
+      this.$router.replace({ name: 'exercise-not-found' })
+    }
+  }
 };
 </script>

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -85,8 +85,8 @@ export default {
   },
   methods: {
     redirectToErrorPage() {
-      this.$router.replace({ name: 'exercise-not-found' })
-    }
-  }
+      this.$router.replace({ name: 'exercise-not-found' });
+    },
+  },
 };
 </script>

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -72,11 +72,11 @@ export default {
     
     this.$store.dispatch('exerciseDocument/bind', id)
       .then((data) => {
-        if(!(data === null)) {
-          this.loaded = true;
+        if(data === null) {
+          this.redirectToErrorPage();
         }
         else {
-          this.redirectToErrorPage();
+          this.loaded = true;
         }
       }).catch((e) => {
         this.loadFailed = true;

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -3,27 +3,7 @@
     <LoadingMessage
       v-if="loaded === false"
       :load-failed="loadFailed"
-    >
-      <template v-slot:failedLoadMessage>
-        <h1 class="govuk-heading-xl">
-          Page not found
-        </h1>
-        <p class="govuk-body">
-          If you typed the web address, check it is correct.
-        </p>
-        <p class="govuk-body">
-          If you pasted the web address, check you copied the entire address.
-        </p>
-        <p class="govuk-body">
-          Come back to Dashboard page: 
-          <router-link
-            to="/dashboard"
-          >
-            Go to Dashboard
-          </router-link>
-        </p>
-      </template>
-    </LoadingMessage>
+    />
     <div v-else>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -96,12 +76,17 @@ export default {
           this.loaded = true;
         }
         else {
-          this.loadFailed = true;
+          this.redirectToErrorPage();
         }
       }).catch((e) => {
         this.loadFailed = true;
         throw e;
       });
   },
+  methods: {
+    redirectToErrorPage() {
+      this.$router.replace({ name: 'exercise-not-found' })
+    }
+  }
 };
 </script>

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -3,7 +3,27 @@
     <LoadingMessage
       v-if="loaded === false"
       :load-failed="loadFailed"
-    />
+    >
+      <template v-slot:failedLoadMessage>
+        <h1 class="govuk-heading-xl">
+          Page not found
+        </h1>
+        <p class="govuk-body">
+          If you typed the web address, check it is correct.
+        </p>
+        <p class="govuk-body">
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p class="govuk-body">
+          Come back to Dashboard page: 
+          <router-link
+            to="/dashboard"
+          >
+            Go to Dashboard
+          </router-link>
+        </p>
+      </template>
+    </LoadingMessage>
     <div v-else>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -71,10 +91,15 @@ export default {
     const id = this.$route.params.id;
     
     this.$store.dispatch('exerciseDocument/bind', id)
-      .then(() => {
-        this.loaded = true;
+      .then((data) => {
+        if(!(data === null)) {
+          this.loaded = true;
+        }
+        else {
+          this.loadFailed = true;
+        }
       }).catch((e) => {
-        this.loadFailed = true;
+        
         throw e;
       });
   },

--- a/src/views/Exercises/Show.vue
+++ b/src/views/Exercises/Show.vue
@@ -99,7 +99,7 @@ export default {
           this.loadFailed = true;
         }
       }).catch((e) => {
-        
+        this.loadFailed = true;
         throw e;
       });
   },

--- a/tests/unit/components/LoadingMessage.spec.js
+++ b/tests/unit/components/LoadingMessage.spec.js
@@ -7,13 +7,10 @@ describe('components/LoadingMessage', () => {
       propsData: {
         loadFailed: loadFailedValue,
       },
-      slots: {
-        failedLoadMessage: "<h1 class='slot'>Test error message</h1>",
-      },
     });
   };
 
-  describe('when loadFailed is equal to false', () => {
+  describe('when `loadFailed` is equal to `false`', () => {
     it('shows the "Loading" message', () => {
       const wrapper = createWrapper(false);
 
@@ -22,7 +19,7 @@ describe('components/LoadingMessage', () => {
     });
   });
 
-  describe('when loadFailed is equal to true', () => {
+  describe('when `loadFailed` is equal to `true`', () => {
     it('shows the errorMessage', () => {
       const wrapper = createWrapper(true);
 

--- a/tests/unit/components/LoadingMessage.spec.js
+++ b/tests/unit/components/LoadingMessage.spec.js
@@ -20,11 +20,6 @@ describe('components/LoadingMessage', () => {
       expect(wrapper.find({ ref: 'loadingMessage' }).isVisible()).toBe(true);
       expect(wrapper.find({ ref: 'errorMessage' }).exists()).toBe(false);
     });
-
-    it('does not render the slot', () => {
-      let slotContainer = createWrapper(false).find('h1.slot');
-      expect(slotContainer.exists()).not.toBe(true);
-    });
   });
 
   describe('when loadFailed is equal to true', () => {
@@ -34,10 +29,5 @@ describe('components/LoadingMessage', () => {
       expect(wrapper.find({ ref: 'errorMessage' }).isVisible()).toBe(true);
       expect(wrapper.find({ ref: 'loadingMessage' }).exists()).toBe(false);
     });
-
-    it('renders the slot', () => {
-        let slotContainer = createWrapper(true).find('h1.slot');
-        expect(slotContainer.exists()).toBe(true);
-      });
   });
 });

--- a/tests/unit/components/LoadingMessage.spec.js
+++ b/tests/unit/components/LoadingMessage.spec.js
@@ -2,52 +2,42 @@ import { shallowMount } from '@vue/test-utils';
 import LoadingMessage from '@/components/LoadingMessage';
 
 describe('components/LoadingMessage', () => {
-  it('shows the "Loading" message if loadFailed is equal to false', () => {
-    const wrapper = shallowMount(LoadingMessage, {
+  const createWrapper = (loadFailedValue) => {
+    return shallowMount(LoadingMessage, {
       propsData: {
-        loadFailed: false,
+        loadFailed: loadFailedValue,
+      },
+      slots: {
+        failedLoadMessage: "<h1 class='slot'>Test error message</h1>",
       },
     });
+  };
 
-    expect(wrapper.find({ ref: 'loadingMessage' }).isVisible()).toBe(true);
-    expect(wrapper.find({ ref: 'errorMessage' }).exists()).toBe(false);
-  });
+  describe('when loadFailed is equal to false', () => {
+    it('shows the "Loading" message', () => {
+      const wrapper = createWrapper(false);
 
-  it('shows the errorMessage message if loadFailed is equal to true', () => {
-    const wrapper = shallowMount(LoadingMessage, {
-      propsData: {
-        loadFailed: true,
-      },
+      expect(wrapper.find({ ref: 'loadingMessage' }).isVisible()).toBe(true);
+      expect(wrapper.find({ ref: 'errorMessage' }).exists()).toBe(false);
     });
 
-    expect(wrapper.find({ ref: 'errorMessage' }).isVisible()).toBe(true);
-    expect(wrapper.find({ ref: 'loadingMessage' }).exists()).toBe(false);
+    it('does not render the slot', () => {
+      let slotContainer = createWrapper(false).find('h1.slot');
+      expect(slotContainer.exists()).not.toBe(true);
+    });
   });
 
-  describe('slot container', () => {
-    const createWrapper = (loadFailedValue) => {
-      return shallowMount(LoadingMessage, {
-        propsData: {
-          loadFailed: loadFailedValue,
-        },
-        slots: {
-          failedLoadMessage: "<h1 class='slot'>Test error message</h1>",
-        },
-      });
-    };
+  describe('when loadFailed is equal to true', () => {
+    it('shows the errorMessage', () => {
+      const wrapper = createWrapper(true);
 
-    describe('when loadFailed is equal to true', () => {
-      it('renders', () => {
+      expect(wrapper.find({ ref: 'errorMessage' }).isVisible()).toBe(true);
+      expect(wrapper.find({ ref: 'loadingMessage' }).exists()).toBe(false);
+    });
+
+    it('renders the slot', () => {
         let slotContainer = createWrapper(true).find('h1.slot');
         expect(slotContainer.exists()).toBe(true);
       });
-    });
-
-    describe('when loadFailed is equal to false', () => {
-      it('does not render', () => {
-        let slotContainer = createWrapper(false).find('h1.slot');
-        expect(slotContainer.exists()).not.toBe(true);
-      });
-    });
   });
 });

--- a/tests/unit/components/LoadingMessage.spec.js
+++ b/tests/unit/components/LoadingMessage.spec.js
@@ -23,4 +23,31 @@ describe('components/LoadingMessage', () => {
     expect(wrapper.find({ ref: 'errorMessage' }).isVisible()).toBe(true);
     expect(wrapper.find({ ref: 'loadingMessage' }).exists()).toBe(false);
   });
+
+  describe('slot container', () => {
+    const createWrapper = (loadFailedValue) => {
+      return shallowMount(LoadingMessage, {
+        propsData: {
+          loadFailed: loadFailedValue,
+        },
+        slots: {
+          failedLoadMessage: "<h1 class='slot'>Test error message</h1>",
+        },
+      });
+    };
+
+    describe('when loadFailed is equal to true', () => {
+      it('renders', () => {
+        let slotContainer = createWrapper(true).find('h1.slot');
+        expect(slotContainer.exists()).toBe(true);
+      });
+    });
+
+    describe('when loadFailed is equal to false', () => {
+      it('does not render', () => {
+        let slotContainer = createWrapper(false).find('h1.slot');
+        expect(slotContainer.exists()).not.toBe(true);
+      });
+    });
+  });
 });

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -18,7 +18,7 @@ const routes = [
   ['exercise-edit-eligibility', 'Eligibility Information'],
   ['exercise-edit-vacancy', 'Vacancy Information'],
   ['exercise-not-found', 'Exercise Not Found'],
-  ['page-not-found', 'Page Not found'],
+  ['page-not-found', 'Page Not Found'],
 ];
 
 describe('Page titles', () => {

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -3,7 +3,7 @@ import App from '@/App';
 import Router from 'vue-router';
 import Vuex from 'vuex';
 
-const exerciseRoutes = [
+const routes = [
   ['exercise-new', 'Create An Exercise'],
   ['exercise-show-overview', 'Exercise Details | Overview'],
   ['exercise-show-applications', 'Exercise Details | Applications'],
@@ -17,6 +17,8 @@ const exerciseRoutes = [
   ['exercise-edit-timeline', 'Timeline'],
   ['exercise-edit-eligibility', 'Eligibility Information'],
   ['exercise-edit-vacancy', 'Vacancy Information'],
+  ['exercise-not-found', 'Exercise Not Found'],
+  ['page-not-found', 'Page Not found'],
 ];
 
 describe('Page titles', () => {
@@ -72,7 +74,7 @@ describe('Page titles', () => {
     });
   });
 
-  describe.each(exerciseRoutes)('%s', (routeName, routeTitle) => {
+  describe.each(routes)('%s', (routeName, routeTitle) => {
      beforeEach(() => {
       store.dispatch('setCurrentUser', user);
       router.push({ name: routeName, params: { id: 123 } });

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -18,8 +18,8 @@ const routes = [
   ['exercise-edit-timeline', `/exercises/${id}/edit/timeline`],
   ['exercise-edit-eligibility', `/exercises/${id}/edit/eligibility`],
   ['exercise-edit-vacancy', `/exercises/${id}/edit/vacancy`],
-  ['exercise-not-found', '/exercise-not-found'],
-  ['page-not-found', '/page-not-found'],
+  ['exercise-not-found', '/errors/exercise-not-found'],
+  ['page-not-found', '/errors/page-not-found'],
 ];
 
 describe('Sign in journey', () => {

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -18,6 +18,8 @@ const routes = [
   ['exercise-edit-timeline', `/exercises/${id}/edit/timeline`],
   ['exercise-edit-eligibility', `/exercises/${id}/edit/eligibility`],
   ['exercise-edit-vacancy', `/exercises/${id}/edit/vacancy`],
+  ['exercise-not-found', '/exercise-not-found'],
+  ['page-not-found', '/page-not-found'],
 ];
 
 describe('Sign in journey', () => {

--- a/tests/unit/views/Errors/ExerciseNotFound.spec.js
+++ b/tests/unit/views/Errors/ExerciseNotFound.spec.js
@@ -1,0 +1,17 @@
+import ExerciseNotFound from '@/views/Errors/ExerciseNotFound';
+import { shallowMount } from '@vue/test-utils';
+
+describe('@/views/ExerciseNotFound', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(ExerciseNotFound);
+  });
+
+  it('renders', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('contains h1', () => {
+    expect(wrapper.find('h1').exists()).toBe(true);
+  });
+});

--- a/tests/unit/views/Errors/PageNotFound.spec.js
+++ b/tests/unit/views/Errors/PageNotFound.spec.js
@@ -1,0 +1,17 @@
+import PageNotFound from '@/views/Errors/PageNotFound';
+import { shallowMount } from '@vue/test-utils';
+
+describe('@/views/ExerciseNotFound', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(PageNotFound);
+  });
+
+  it('renders', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('contains h1', () => {
+    expect(wrapper.find('h1').exists()).toBe(true);
+  });
+});

--- a/tests/unit/views/Exercises/Edit.spec.js
+++ b/tests/unit/views/Exercises/Edit.spec.js
@@ -102,9 +102,10 @@ describe('@/views/Exercises/Edit', () => {
 
   describe('methods', () => {
     describe('redirectToErrorPage', () => {
-      it('calls router replace method', () => {
+      it('calls router replace method with the name of error page', () => {
         wrapper.vm.redirectToErrorPage();
         expect(mockRouter.replace).toHaveBeenCalled();
+        expect(mockRouter.replace.mock.calls[0][0]).toEqual({ 'name': 'exercise-not-found' });
       });
     });
   });

--- a/tests/unit/views/Exercises/Edit.spec.js
+++ b/tests/unit/views/Exercises/Edit.spec.js
@@ -13,11 +13,16 @@ const mockRoute = {
   },
 };
 
+const mockRouter = {
+  replace: jest.fn(),
+};
+
 const createTestSubject = () => {
   return shallowMount(Edit, {
     mocks: {
       $store: mockStore,
       $route: mockRoute,
+      $router: mockRouter,
     },
     stubs: {
       RouterView: true,
@@ -74,7 +79,7 @@ describe('@/views/Exercises/Edit', () => {
     });
   });
 
-  describe.only('watchers', () => {
+  describe('watchers', () => {
     describe('when $route changes', () => {
       it('updates `exerciseCreateJourney` with the current route name', () => {
         // Trigger the $route watcher function
@@ -91,6 +96,15 @@ describe('@/views/Exercises/Edit', () => {
         const calls = mockStore.dispatch.mock.calls;
         expect(calls[0]).toEqual(['exerciseCreateJourney/setCurrentRoute', 'page-one']);
         expect(calls[1]).toEqual(['exerciseCreateJourney/setCurrentRoute', 'page-two']);
+      });
+    });
+  });
+
+  describe('methods', () => {
+    describe('redirectToErrorPage', () => {
+      it('calls router replace method', () => {
+        wrapper.vm.redirectToErrorPage();
+        expect(mockRouter.replace).toHaveBeenCalled();
       });
     });
   });

--- a/tests/unit/views/Exercises/Show.spec.js
+++ b/tests/unit/views/Exercises/Show.spec.js
@@ -1,17 +1,25 @@
 import Show from '@/views/Exercises/Show';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Router from 'vue-router';
 import Vuex from 'vuex';
 import Navigation from '@/components/Page/Navigation';
 import LoadingMessage from '@/components/LoadingMessage';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-localVue.use(Router);
 
-const router = new Router();
 const exercise = {
   name: 'test name',
+};
+
+const mockRoute = {
+  name: 'name-of-current-route',
+  params: {
+    id: 'abc123',
+  },
+};
+
+const mockRouter = {
+  replace: jest.fn(),
 };
 
 const store = new Vuex.Store({
@@ -37,7 +45,10 @@ const createTestSubject = () => {
   return shallowMount(Show, {
     store,
     localVue,
-    router,
+    mocks: {
+      $route: mockRoute,
+      $router: mockRouter,
+    },
     stubs: {
       'RouterView': true,
     },
@@ -85,6 +96,16 @@ describe('@/views/Exercises/Show', () => {
 
       it('renders the RouterView', () => {
         expect(wrapper.find('RouterView-stub').exists()).toBe(true);
+      });
+    });
+  });
+
+  describe('methods', () => {
+    describe('redirectToErrorPage', () => {
+      it('calls router replace method', () => {
+        let wrapper = createTestSubject();
+        wrapper.vm.redirectToErrorPage();
+        expect(mockRouter.replace).toHaveBeenCalled();
       });
     });
   });

--- a/tests/unit/views/Exercises/Show.spec.js
+++ b/tests/unit/views/Exercises/Show.spec.js
@@ -11,6 +11,15 @@ const exercise = {
   name: 'test name',
 };
 
+let mockStore = {
+  dispatch: jest.fn().mockResolvedValue(),
+  state: {
+    exerciseDocument: {
+      record: exercise,
+    },
+  },
+};
+
 const mockRoute = {
   name: 'name-of-current-route',
   params: {
@@ -22,32 +31,13 @@ const mockRouter = {
   replace: jest.fn(),
 };
 
-const store = new Vuex.Store({
-  dispatch: jest.fn(),
-  modules: {
-    exerciseDocument: {
-      namespaced: true,
-      actions: {
-        bind: () => {
-          new Promise((resolve) => {
-            return resolve();
-          });
-        },
-      },
-      state: {
-        record: exercise,
-      },
-    },
-  },
-});
-
 const createTestSubject = () => {
   return shallowMount(Show, {
-    store,
     localVue,
     mocks: {
       $route: mockRoute,
       $router: mockRouter,
+      $store: mockStore,
     },
     stubs: {
       'RouterView': true,
@@ -56,6 +46,11 @@ const createTestSubject = () => {
 };
 
 describe('@/views/Exercises/Show', () => {
+
+  beforeEach(() => {
+    mockStore.dispatch.mockClear();
+  });
+
   describe('computed properties', () => {
     describe('exercise', () => {
       it('returns record object from state', () => {
@@ -102,10 +97,11 @@ describe('@/views/Exercises/Show', () => {
 
   describe('methods', () => {
     describe('redirectToErrorPage', () => {
-      it('calls router replace method', () => {
+      it('calls router replace method with the name of error page', () => {
         let wrapper = createTestSubject();
         wrapper.vm.redirectToErrorPage();
         expect(mockRouter.replace).toHaveBeenCalled();
+        expect(mockRouter.replace.mock.calls[0][0]).toEqual({ 'name': 'exercise-not-found' });
       });
     });
   });


### PR DESCRIPTION
This PR adds two 404 pages:
- Main 404 ("Page is not found")
- Exercise 404 ("Exercises is not found")

Also, this PR changes the error message in LoadingMessage component to be "Something went wrong"

**Change log**
1) Create 404 pages
2) Redirect to Exercise 404 page if exercise data is null using Vur router replace() method