### PR TITLE
Make exercise page headings add/edit agnostic

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -135,7 +135,7 @@ const router = new Router({
           name: 'exercise-edit-contacts',
           meta: {
             requiresAuth: true,
-            title: 'Add Exercise Contacts',
+            title: 'Contacts',
           },
         },
         {
@@ -144,7 +144,7 @@ const router = new Router({
           name: 'exercise-edit-shortlisting',
           meta: {
             requiresAuth: true,
-            title: 'Add Shortlisting Methods',
+            title: 'Shortlisting Methods',
           },
         },
         {
@@ -153,7 +153,7 @@ const router = new Router({
           name: 'exercise-edit-timeline',
           meta: {
             requiresAuth: true,
-            title: 'Add Exercise Timeline',
+            title: 'Timeline',
           },
         },
         {
@@ -162,7 +162,7 @@ const router = new Router({
           name: 'exercise-edit-eligibility',
           meta: {
             requiresAuth: true,
-            title: 'Add Eligibility Information',
+            title: 'Eligibility Information',
           },
         },
         {
@@ -171,7 +171,7 @@ const router = new Router({
           name: 'exercise-edit-vacancy',
           meta: {
             requiresAuth: true,
-            title: 'About The Vacancy',
+            title: 'Vacancy Information',
           },
         },
       ],

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -10,7 +10,7 @@
           Back
         </a>
         <h1 class="govuk-heading-xl">
-          Add exercise contacts
+          Contacts
         </h1>
 
         <p class="govuk-body-l">

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -3,7 +3,7 @@
     <form @submit.prevent="save">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">
-          Add eligibility information
+          Eligibility information
         </h1>
 
         <p class="govuk-body-l">

--- a/src/views/Exercises/Edit/Shortlisting.vue
+++ b/src/views/Exercises/Edit/Shortlisting.vue
@@ -11,7 +11,7 @@
         </a>
 
         <h1 class="govuk-heading-xl">
-          Add shortlisting methods
+          Shortlisting methods
         </h1>
 
         <p class="govuk-body-l">

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -11,7 +11,7 @@
         </a>
 
         <h1 class="govuk-heading-xl">
-          Add exercise timeline
+          Timeline
         </h1>
         <p class="govuk-body-l">
           You can return to this page later to add or change dates.

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -11,7 +11,7 @@
         </a>
 
         <h1 class="govuk-heading-xl">
-          About the vacancy
+          Vacancy information
         </h1>
 
         <p class="govuk-body-l">

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -12,11 +12,11 @@ const exerciseRoutes = [
   ['exercise-show-shortlisting', 'Exercise Details | Shortlisting'],
   ['exercise-show-vacancy', 'Exercise Details | Vacancy information'],
   ['exercise-show-eligibility', 'Exercise Details | Eligibility information'],
-  ['exercise-edit-contacts', 'Add Exercise Contacts'],
-  ['exercise-edit-shortlisting', 'Add Shortlisting Methods'],
-  ['exercise-edit-timeline', 'Add Exercise Timeline'],
-  ['exercise-edit-eligibility', 'Add Eligibility Information'],
-  ['exercise-edit-vacancy', 'About The Vacancy'],
+  ['exercise-edit-contacts', 'Contacts'],
+  ['exercise-edit-shortlisting', 'Shortlisting Methods'],
+  ['exercise-edit-timeline', 'Timeline'],
+  ['exercise-edit-eligibility', 'Eligibility Information'],
+  ['exercise-edit-vacancy', 'Vacancy Information'],
 ];
 
 describe('Page titles', () => {


### PR DESCRIPTION
[Trello card](https://trello.com/c/l6X40p9H/148-make-edit-page-headings-add-edit-agnostic)

---

The exercise edit pages now have add/edit agnostic headings.

Page headings used to read, for example, 'Add exercise contacts'

However, the same pages are used both in the 'Create an exercise' journey and the regular edit journey.

The UX team therefore made the decision that page headings on these edit pages should become 'agnostic' of whether they're in a 'create' journey or a regular 'edit' journey.