### PR TITLE
V2.2

### DIFF
--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -67,10 +67,6 @@
             label="Senior President of Tribunals (SPT)"
           />
           <CheckboxItem
-            value="senior-presiding-judge"
-            label="Senior Presiding Judge (SPJ)"
-          />
-          <CheckboxItem
             value="scottish-ministers"
             label="Scottish ministers"
           />
@@ -93,7 +89,7 @@
         <TextField
           id="hmcts-welshgov-lead"
           v-model="exercise.hmctsWelshGovLead"
-          label="HMCTS or Welsh Government lead"
+          label="HMCTS or Welsh Government lead contact"
         />
 
         <TextField

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -8,7 +8,7 @@
         </h1>
 
         <p class="govuk-body-l">
-          You'll find this information in the eligibility statement from HMCTS.
+          You'll find this information in the eligibility statement from HMCTS. You can return to this page later to add or change information.
         </p>
 
         <RadioGroup
@@ -41,8 +41,47 @@
         <RadioGroup
           id="schedule-2d-apply"
           v-model="exercise.schedule2DApply"
-          label="Does Schedule 2(d) apply?"
-          hint="This lets appropriate candidates apply, even if they do not have the right legal experience."
+          label="Does Schedule 2(d) or Schedule 3 apply?"
+          hint="This lets appropriate candidates apply, even if they don't have the right qualifications. It only applies to tribunal vacancies."
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          id="additional-selection-criteria-apply"
+          v-model="exercise.aSCApply"
+          label="Does additional selection criteria (ASC) apply?"
+          hint="This is also known as non-statutory eligibility. It describes what additional skills or experience candidates must have."
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          >
+            <TextareaInput
+              id="yes-asc-apply"
+              v-model="exercise.yesASCApply"
+              label="Additional skills and experience"
+            />
+          </RadioItem>
+
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          id="previous-judicial-experience-apply"
+          v-model="exercise.previousJudicialExperienceApply"
+          label="Does previous judicial experience (PJE) apply?"
         >
           <RadioItem
             :value="true"
@@ -85,32 +124,10 @@
               id="other-qualifications"
               v-model="exercise.otherQualifications"
               label="Add details of other relevant professions, qualifications or experience"
+              hint="For example, Patent attorney."
             />
           </CheckboxItem>
         </CheckboxGroup>
-
-        <RadioGroup
-          id="additional-selection-criteria-apply"
-          v-model="exercise.aSCApply"
-          label="Does additional selection criteria (ASC) apply?"
-          hint="This is also known as non-statutory eligibility. It describes what additional skills or experience candidates must have."
-        >
-          <RadioItem
-            :value="true"
-            label="Yes"
-          >
-            <TextareaInput
-              id="yes-asc-apply"
-              v-model="exercise.yesASCApply"
-              label="Additional skills and experience"
-            />
-          </RadioItem>
-
-          <RadioItem
-            :value="false"
-            label="No"
-          />
-        </RadioGroup>
 
         <RadioGroup
           id="reasonable-length-service"
@@ -201,10 +218,11 @@ export default {
         postQualificationExperience: exercise.postQualificationExperience || null,
         otherYears: exercise.otherYears || null,
         schedule2DApply: booleanOrNull(exercise.schedule2DApply),
-        qualifications: exercise.qualifications || null,
-        otherQualifications: exercise.otherQualifications || null,
         aSCApply: booleanOrNull(exercise.aSCApply),
         yesASCApply: exercise.yesASCApply || null,
+        previousJudicialExperienceApply: booleanOrNull(exercise.previousJudicialExperienceApply),
+        qualifications: exercise.qualifications || null,
+        otherQualifications: exercise.otherQualifications || null,
         reasonableLengthService: exercise.reasonableLengthService || null,
         otherLOS: exercise.otherLOS || null,
         retirementAge: exercise.retirementAge || null,

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -58,12 +58,6 @@
           v-model="exercise.sjcaTestEndTime"
           label="End time"
         />
-        <DateInput
-          id="test-outcome"
-          v-model="exercise.sjcaTestOutcome"
-          label="Outcome to candidates"
-          type="month"
-        />
 
         <h3 class="govuk-heading-m">
           Scenario test qualifying test (QT)
@@ -83,12 +77,6 @@
           v-model="exercise.scenarioTestEndTime"
           label="End time"
         />
-        <DateInput
-          id="test-outcome"
-          v-model="exercise.scenarioTestOutcome"
-          label="Outcome to candidates"
-          type="month"
-        />
 
         <h2 class="govuk-heading-l">
           Independent assessors
@@ -102,29 +90,12 @@
         />
 
         <h2 class="govuk-heading-l">
-          Selection day dates
+          Selection day
         </h2>
 
         <RepeatableFields
           v-model="exercise.selectionDays"
           :component="repeatableFields.SelectionDay"
-        />
-
-        <h2 class="govuk-heading-l">
-          Candidate checks
-        </h2>
-
-        <DateInput
-          id="character-checks"
-          v-model="exercise.characterChecks"
-          label="Character checks"
-          type="month"
-        />
-        <DateInput
-          id="statutory-consultation"
-          v-model="exercise.statutoryConsultation"
-          label="Statutory consultation"
-          type="month"
         />
 
         <h2 class="govuk-heading-l">
@@ -134,7 +105,7 @@
         <DateInput
           id="final-outcome"
           v-model="exercise.finalOutcome"
-          label="Final outcome"
+          label="Final outcome to candidates"
           type="month"
         />
 
@@ -173,16 +144,12 @@ export default {
         sjcaTestDate: exercise.sjcaTestDate || null,
         sjcaTestStartTime: exercise.sjcaTestStartTime || null,
         sjcaTestEndTime: exercise.sjcaTestEndTime || null,
-        sjcaTestOutcome: exercise.sjcaTestOutcome || null,
         scenarioTestDate: exercise.scenarioTestDate ||null,
         scenarioTestStartTime: exercise.scenarioTestStartTime || null,
         scenarioTestEndTime: exercise.scenarioTestEndTime || null,
-        scenarioTestOutcome: exercise.scenarioTestOutcome || null,
         contactIndependentAssessors: exercise.contactIndependentAssessors || null,
         selectionDayStart: exercise.selectionDayStart || null,
         selectionDayEnd: exercise.selectionDayEnd || null,
-        characterChecks: exercise.characterChecks || null,
-        statutoryConsultation: exercise.statutoryConsultation || null,
         finalOutcome: exercise.finalOutcome || null,
         selectionDays: exercise.selectionDays || [],
       },

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -8,7 +8,7 @@
         </h1>
 
         <p class="govuk-body-l">
-          You'll find this information in the vacancy request (VR) from HMCTS.
+          You'll find this information in the vacancy request (VR) from HMCTS. You can return to this page later to add or change information.
         </p>
 
         <RadioGroup
@@ -60,7 +60,7 @@
           >
             <div class="govuk-form-group">
               <label
-                class="govuk-label"
+                class="govuk-heading-m govuk-!-margin-bottom-2"
                 for="salary-group"
               >
                 Salary group
@@ -69,35 +69,41 @@
                 id="salary-group"
                 class="govuk-select"
               >
+                <option value="">
+                  Select an option
+                </option>
                 <option value="group1">
-                  Group 1
+                  Group 1 - £262,264
                 </option>
                 <option value="group1.1">
-                  Group 1.1
+                  Group 1.1 - £234,184
                 </option>
                 <option value="group2">
-                  Group 2
+                  Group 2 - £226,193
                 </option>
                 <option value="group3">
-                  Group 3
+                  Group 3 - £215,094
                 </option>
                 <option value="group4">
-                  Group 4
+                  Group 4 - £188,901
                 </option>
                 <option value="group5+">
-                  Group 5+
+                  Group 5+ - £160,377
                 </option>
                 <option value="group5">
-                  Group 5
+                  Group 5 - £151,497
                 </option>
                 <option value="group6.1">
-                  Group 6.1
+                  Group 6.1 - £140,289
                 </option>
                 <option value="group6.2">
-                  Group 6.7
+                  Group 6.7 - £132,075
                 </option>
                 <option value="group7">
-                  Group 7
+                  Group 7 - £112,542
+                </option>
+                <option value="group8">
+                  Group 8 - £89,428
                 </option>
               </select>
             </div>
@@ -106,7 +112,7 @@
             value="fee-paid"
             label="Fee paid"
           >
-            <Currency
+            <TextField
               id="fee-paid-fee"
               v-model="exercise.feePaidFee"
               label="Fee"
@@ -179,13 +185,6 @@
           hint="For example, Employment, Family."
         />
 
-        <TextareaInput
-          id="about-the-role"
-          v-model="exercise.aboutTheRole"
-          label="About the role"
-          hint="Add information about this role for the information page."
-        />
-
         <CheckboxGroup
           id="welsh-requirement"
           v-model="exercise.welshRequirement"
@@ -201,6 +200,17 @@
             label="Devolution questions"
           />
         </CheckboxGroup>
+
+        <h2 class="govuk-label-input">
+          Additional information
+        </h2>
+
+        <TextareaInput
+          id="about-the-role"
+          v-model="exercise.aboutTheRole"
+          label="About the role"
+          hint="Add information about this role for the information page."
+        />
 
         <h2 class="govuk-label-input">
           Upload HMCTS documents
@@ -248,7 +258,6 @@ import RadioItem from '@/components/Form/RadioItem';
 import TextField from '@/components/Form/TextField';
 import CheckboxGroup from '@/components/Form/CheckboxGroup';
 import CheckboxItem from '@/components/Form/CheckboxItem';
-import Currency from '@/components/Form/Currency';
 import TextareaInput from '@/components/Form/TextareaInput';
 import booleanOrNull from '@/helpers/booleanOrNull';
 import BackLink from '@/components/BackLink';
@@ -260,7 +269,6 @@ export default {
     TextField,
     CheckboxGroup,
     CheckboxItem,
-    Currency,
     TextareaInput,
     BackLink,
   },
@@ -280,8 +288,9 @@ export default {
         futureStart: exercise.futureStart || null,
         location: exercise.location || null,
         jurisdiction: exercise.jurisdiction || null,
-        aboutTheRole: exercise.aboutTheRole || null,
         welshRequirement: exercise.welshRequirement || [],
+        aboutTheRole: exercise.aboutTheRole || null,
+
       },
     };
   },

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -97,7 +97,7 @@
                   Group 6.1 - £140,289
                 </option>
                 <option value="group6.2">
-                  Group 6.7 - £132,075
+                  Group 6.2 - £132,075
                 </option>
                 <option value="group7">
                   Group 7 - £112,542

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -201,7 +201,7 @@
           />
         </CheckboxGroup>
 
-        <h2 class="govuk-label-input">
+        <h2 class="govuk-heading-l">
           Additional information
         </h2>
 


### PR DESCRIPTION
Amended the Edit pages for the `Create an Exercise` journey, to be in line with V2.2 of the Prototype. 

Used Kellie's change log and a list I made of visual differences to make these changes (please let me know if I've still missed something. 

**Eligibility page:** 
- Added an extra sentence to the leading p tag on the page. 
- Added "or Schedule 3?" to the 'schedule 2' label. Also changed the 
hint text on this question.
- Rearranged the order of the questions on the page.
- Added a 'Previous Judicial Experience' radio group.
- Changed the hint text on the 'other' textfield under the 
'Qualifications' checkbox.

**Vacancy page:** 
- Added an additional sentence to the page's main P tag.
- Added GBP salaries to the Salary drop down, along with a basic place 
holder option.
- Made 'salary grouping' label the same styling as the component labels.
- Removed the currency component in the  'fee paid' option under the 
'Appointment type' checkbox.
- Moved the 'Welsh requirement' checkbox under the 'jurisdiction' 
textarea.
- Added an 'Additional information' header before the 'About the role' 
text area.

**Timeline page:** 
- 'Outcome to candidates' field removed from the two shortlisting type 
sections. 
- "dates" has been removed from the 'Selection day' header.
- Removed the 'Candidate checks' section. 
- Added "to candidates" to the 'Final Outcome' labels. 

**Contacts page:** 
- Removed 'Senior Presiding Judge' from 'Appropriate authority' 
checkbox. 
- Added "contact" to the 'HMCTS or Welsh Government lead' label. 




