### PR TITLE
Refactored the components' 'label' styling

### DIFF
--- a/src/components/Form/CheckboxGroup.vue
+++ b/src/components/Form/CheckboxGroup.vue
@@ -9,7 +9,7 @@
     >
       <legend
         v-if="label"
-        class="govuk-fieldset__legend govuk-fieldset__legend--m"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2"
       >
         {{ label }}
       </legend>

--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -7,7 +7,7 @@
     >
       <legend
         v-if="label"
-        class="govuk-fieldset__legend govuk-fieldset__legend--m"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2"
       >
         {{ label }}
       </legend>

--- a/src/components/Form/RadioGroup.vue
+++ b/src/components/Form/RadioGroup.vue
@@ -9,7 +9,7 @@
     >
       <legend
         v-if="label"
-        class="govuk-fieldset__legend govuk-fieldset__legend--m"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2"
       >
         {{ label }}
       </legend>

--- a/src/components/Form/TimeInput.vue
+++ b/src/components/Form/TimeInput.vue
@@ -7,7 +7,7 @@
     >
       <legend
         v-if="label"
-        class="govuk-fieldset__legend govuk-fieldset__legend--m"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-2"
       >
         {{ label }}
       </legend>


### PR DESCRIPTION
- For all components that have a typical 'heading like' label, I have 
added the `govuk-!-margin-bottom-2` style to it. This is to standardise 
the labelling across all components. Textfield, TextareaInput, and Currency already had this styling applied.

- I have left out Repeatable fields, CheckboxItem and RadioItem, as 
these components did not have a need for the styling to change. 

All code has been linted and tests are passing.