### PR TITLE
Added a conditional reveal to the schedule 2(d) field

### DIFF
--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -39,6 +39,7 @@
         </RadioGroup>
 
         <RadioGroup
+          v-if="isCourtOrTribunal === 'tribunal'"
           id="schedule-2d-apply"
           v-model="exercise.schedule2DApply"
           label="Does Schedule 2(d) or Schedule 3 apply?"
@@ -228,6 +229,7 @@ export default {
         retirementAge: exercise.retirementAge || null,
         otherRetirement: exercise.otherRetirement || null,
       },
+      isCourtOrTribunal: exercise.isCourtOrTribunal,
     };
   },
   methods: {

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -62,6 +62,18 @@ describe('views/Exercises/Edit/Eligibility', () => {
       expect(button.element.type).toBe('submit');
       expect(button.text()).toBe('Save and continue');
     });
+
+    describe('Does Schedule 2(d) or Schedule 3 apply?', () => {
+      it('does not show the question if the role is a court role', () => {
+        wrapper.setData({ isCourtOrTribunal: 'court' });
+        expect(wrapper.find('#schedule-2d-apply').exists()).toBe(false);
+      });
+
+      it('does show the question if the role is a tribunal role', () => {
+        wrapper.setData({ isCourtOrTribunal: 'tribunal' });
+        expect(wrapper.find('#schedule-2d-apply').exists()).toBe(true);
+      });
+    });
   });
 
   describe('data', () => {


### PR DESCRIPTION
- Added a v-if to the 'does schedule 2(d) or Schedule 3 apply?' question 
that only shows if the `isCourtOrTribunal` field is equal to 'tribunal'. 

- Tests have been added to test this conditional reveal.

All code has been linted and tests are passing.