### PR TITLE
Amended the styling of the Repeatable Fields component buttons

### DIFF
--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -88,24 +88,3 @@ export default {
   },
 };
 </script>
-
-<style>
-  button.govuk-link {
-    padding: 0;
-    margin: 0;
-    background-color: transparent;
-    border: 0;
-    color: #1d70b8;
-    font-size: 1em;
-    text-decoration: underline;
-    cursor: pointer;
-  }
-
-  button.govuk-link.govuk-link-delete {
-    color: red;
-  }
-
-  .repeatableField .govuk-form-group {
-    margin-bottom: 1em;
-  }
-</style>

--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -14,7 +14,7 @@
         <template v-slot:removeButton>
           <button
             type="button"
-            class="govuk-link govuk-link-delete govuk-!-margin-bottom-4"
+            class="govuk-button govuk-button--warning govuk-!-margin-bottom-2"
             @click.prevent="removeRow(index)"
           >
             Remove
@@ -25,7 +25,7 @@
     <button
       v-if="canAddRow"
       type="button"
-      class="govuk-link govuk-!-margin-bottom-6"
+      class="govuk-button govuk-button--secondary govuk-!-margin-bottom-6"
       @click.prevent="addRow"
     >
       Add another


### PR DESCRIPTION
This PR changes the styling of the button only. I've used the GOVUK design to reflect the buttons that the UX team wanted.

- Changed the 'Add another' and 'Remove' button styling to match the 
V2.2 prototype. No tests have been written (Wasn't sure they were 
needed). 

All code has been linted and tests are passing.