### PR TITLE
Add check for number of rows

### DIFF
--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -13,6 +13,8 @@
       >
         <template v-slot:removeButton>
           <button
+            v-if="rows.length > 1"
+            ref="removeFieldButton"
             type="button"
             class="govuk-button govuk-button--warning govuk-!-margin-bottom-2"
             @click.prevent="removeRow(index)"

--- a/tests/unit/components/RepeatableFields.spec.js
+++ b/tests/unit/components/RepeatableFields.spec.js
@@ -132,7 +132,7 @@ describe('components/RepeatableFields', () => {
             component: SelectionExerciseOfficer }
           );
 
-          let buttons = wrapper.findAll('.govuk-button--warning');
+          let buttons = wrapper.findAll({ref: 'removeFieldButton'});
           expect(buttons).toHaveLength(3);
         });
       });
@@ -144,7 +144,7 @@ describe('components/RepeatableFields', () => {
             component: SelectionExerciseOfficer }
           );
 
-          let buttons = wrapper.findAll('.govuk-button--warning');
+          let buttons = wrapper.findAll({ref: 'removeFieldButton'});
           expect(buttons).toHaveLength(0);
         });
       });

--- a/tests/unit/components/RepeatableFields.spec.js
+++ b/tests/unit/components/RepeatableFields.spec.js
@@ -132,7 +132,7 @@ describe('components/RepeatableFields', () => {
             component: SelectionExerciseOfficer }
           );
 
-          let buttons = wrapper.findAll({ref: 'removeFieldButton'});
+          let buttons = wrapper.findAll({ ref: 'removeFieldButton' });
           expect(buttons).toHaveLength(3);
         });
       });
@@ -144,7 +144,7 @@ describe('components/RepeatableFields', () => {
             component: SelectionExerciseOfficer }
           );
 
-          let buttons = wrapper.findAll({ref: 'removeFieldButton'});
+          let buttons = wrapper.findAll({ ref: 'removeFieldButton' });
           expect(buttons).toHaveLength(0);
         });
       });

--- a/tests/unit/components/RepeatableFields.spec.js
+++ b/tests/unit/components/RepeatableFields.spec.js
@@ -1,10 +1,12 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import RepeatableFields from '@/components/RepeatableFields';
 // import TextField to test with a component
 import TextField from '@/components/Form/TextField';
+// import SelectionExerciseOfficer to test slot
+import SelectionExerciseOfficer from '@/components/RepeatableFields/SelectionExerciseOfficer';
 
 const createTestSubject = (props) => {
-  return shallowMount(RepeatableFields, {
+  return mount(RepeatableFields, {
     propsData: {
       value: null,
       component: TextField,
@@ -118,6 +120,32 @@ describe('components/RepeatableFields', () => {
 
         it('renders number of components equal to the length of the array', () => {
           expect(wrapper.findAll(TextField)).toHaveLength(3);
+        });
+      });
+    });
+
+    describe('Remove button slot', () => {
+      describe('when there are more then one repeatable field', () => {
+        it('render a button for every repeatable field', () => {
+          wrapper = createTestSubject(
+            { value: [{ name: 'first' }, { name: 'second' }, { name: 'third' }],
+            component: SelectionExerciseOfficer }
+          );
+
+          let buttons = wrapper.findAll('.govuk-button--warning');
+          expect(buttons).toHaveLength(3);
+        });
+      });
+
+      describe('when there is only one field', () => {
+        it("doesn't render", () => {
+          wrapper = createTestSubject(
+            { value: [{ name: 'first' }],
+            component: SelectionExerciseOfficer }
+          );
+
+          let buttons = wrapper.findAll('.govuk-button--warning');
+          expect(buttons).toHaveLength(0);
         });
       });
     });


### PR DESCRIPTION
This PR restricts rendering of the Remove button in a case when only one repeatable field is rendered.

**Change log**
1) Render Remove slot only if there is more than one field
2) Tests