### PR TITLE
Additional amendments to the Eligibility Information page - *Will cause merge conflicts*

### DIFF
--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -12,6 +12,7 @@
         </p>
 
         <RadioGroup
+          v-if="typeOfExercise !== 'non-legal'"
           id="post-qualification-experience"
           v-model="exercise.postQualificationExperience"
           label="Post-qualification experience (PQE)"
@@ -230,6 +231,7 @@ export default {
         otherRetirement: exercise.otherRetirement || null,
       },
       isCourtOrTribunal: exercise.isCourtOrTribunal,
+      typeOfExercise: exercise.typeOfExercise,
     };
   },
   methods: {

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -74,6 +74,28 @@ describe('views/Exercises/Edit/Eligibility', () => {
         expect(wrapper.find('#schedule-2d-apply').exists()).toBe(true);
       });
     });
+
+    describe('Post qualification experience', () => {
+      it('does not show the question if the role is a non-legal role', () => {
+        wrapper.setData({ typeOfExercise: 'non-legal' });
+        expect(wrapper.find('#post-qualification-experience').exists()).toBe(false);
+      });
+
+      it('does show the question if the role is a legal role', () => {
+        wrapper.setData({ typeOfExercise: 'legal' });
+        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+      });
+
+      it('does show the question if the role is a senior role', () => {
+        wrapper.setData({ typeOfExercise: 'senior' });
+        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+      });
+
+      it('does show the question if the role is a leadership role', () => {
+        wrapper.setData({ typeOfExercise: 'leadership' });
+        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+      });
+    });
   });
 
   describe('data', () => {


### PR DESCRIPTION
This PR *also* contains amendments to the Eligibility Information page. This could cause a merge conflict, so treat it carefully. 

Things that have been completed:
- The 'Post Qualification Experience' question only renders if the role is _not_ 'non-legal'. (ie You will _not_ see the PQE question if typeOfExercise is equal to 'non-legal'.)

Tests have been written and are passing. 

Code has been linted.