### PR TITLE
Amendments to the Eligibility Information page

### DIFF
--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -97,7 +97,7 @@
         </RadioGroup>
 
         <CheckboxGroup
-          v-if="typeOfExercise !== 'non-legal'"
+          v-if="typeOfExercise !== 'non-legal' "
           id="qualifications"
           v-model="exercise.qualifications"
           label="Qualifications"
@@ -133,7 +133,7 @@
         </CheckboxGroup>
 
         <RadioGroup
-          v-if="typeOfExercise === 'non-legal'"
+          v-if="typeOfExercise === 'non-legal' || typeOfExercise === 'leadership'"
           id="memberships"
           v-model="exercise.memberships"
           label="Memberships"

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -159,10 +159,6 @@
             label="Royal College of Psychaitrists"
           />
           <RadioItem
-            value="royal-chartered-institute-of-surveyors"
-            label="Royal Chartered Institute of Surveyors"
-          />
-          <RadioItem
             value="royal-institution-of-chartered-surveyors"
             label="Royal Institution of Chartered Surveyors"
           />

--- a/src/views/Exercises/Edit/Eligibility.vue
+++ b/src/views/Exercises/Edit/Eligibility.vue
@@ -97,6 +97,7 @@
         </RadioGroup>
 
         <CheckboxGroup
+          v-if="typeOfExercise !== 'non-legal'"
           id="qualifications"
           v-model="exercise.qualifications"
           label="Qualifications"
@@ -130,6 +131,56 @@
             />
           </CheckboxItem>
         </CheckboxGroup>
+
+        <RadioGroup
+          v-if="typeOfExercise === 'non-legal'"
+          id="memberships"
+          v-model="exercise.memberships"
+          label="Memberships"
+        >
+          <RadioItem
+            value="chartered-association-of-building-engineers"
+            label="Chartered Association of Building Engineers"
+          />
+          <RadioItem
+            value="chartered-institute-of-building"
+            label="Chartered Institute of Building"
+          />
+          <RadioItem
+            value="chartered-institute-of-environmental-health"
+            label="Chartered Institute of Environmental Health"
+          />
+          <RadioItem
+            value="general-medical-council"
+            label="General Medical Council"
+          />
+          <RadioItem
+            value="royal-college-of-psychiatrists"
+            label="Royal College of Psychaitrists"
+          />
+          <RadioItem
+            value="royal-chartered-institute-of-surveyors"
+            label="Royal Chartered Institute of Surveyors"
+          />
+          <RadioItem
+            value="royal-institution-of-chartered-surveyors"
+            label="Royal Institution of Chartered Surveyors"
+          />
+          <RadioItem
+            value="royal-institute-of-british-architects"
+            label="Royal Institute of British Architects"
+          />
+          <RadioItem
+            value="other"
+            label="Other"
+          >
+            <TextField
+              id="other-qualifications"
+              v-model="exercise.otherMemberships"
+              label="Associations or Institutes"
+            />
+          </RadioItem>
+        </RadioGroup>
 
         <RadioGroup
           id="reasonable-length-service"
@@ -225,6 +276,8 @@ export default {
         previousJudicialExperienceApply: booleanOrNull(exercise.previousJudicialExperienceApply),
         qualifications: exercise.qualifications || null,
         otherQualifications: exercise.otherQualifications || null,
+        memberships: exercise.memberships || null,
+        otherMemberships: exercise.otherMemberships || null,
         reasonableLengthService: exercise.reasonableLengthService || null,
         otherLOS: exercise.otherLOS || null,
         retirementAge: exercise.retirementAge || null,

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -108,9 +108,9 @@ describe('views/Exercises/Edit/Eligibility', () => {
         expect(wrapper.find('#memberships').exists()).toBe(false);
       });
 
-      it('does not show the question if the role is a leadership role', () => {
+      it('does show the question if the role is a leadership role', () => {
         wrapper.setData({ typeOfExercise: 'leadership' });
-        expect(wrapper.find('#memberships').exists()).toBe(false);
+        expect(wrapper.find('#memberships').exists()).toBe(true);
       });
 
       it('does show the question if the role is a non-legal role', () => {

--- a/tests/unit/views/Exercises/Edit/Eligibility.spec.js
+++ b/tests/unit/views/Exercises/Edit/Eligibility.spec.js
@@ -75,25 +75,47 @@ describe('views/Exercises/Edit/Eligibility', () => {
       });
     });
 
-    describe('Post qualification experience', () => {
+    describe('Qualifications', () => {
       it('does not show the question if the role is a non-legal role', () => {
         wrapper.setData({ typeOfExercise: 'non-legal' });
-        expect(wrapper.find('#post-qualification-experience').exists()).toBe(false);
+        expect(wrapper.find('#qualifications').exists()).toBe(false);
       });
 
       it('does show the question if the role is a legal role', () => {
         wrapper.setData({ typeOfExercise: 'legal' });
-        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+        expect(wrapper.find('#qualifications').exists()).toBe(true);
       });
 
       it('does show the question if the role is a senior role', () => {
         wrapper.setData({ typeOfExercise: 'senior' });
-        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+        expect(wrapper.find('#qualifications').exists()).toBe(true);
       });
 
       it('does show the question if the role is a leadership role', () => {
+        wrapper.setData({ typeOfExercise: 'leadershop' });
+        expect(wrapper.find('#qualifications').exists()).toBe(true);
+      });
+    });
+
+    describe('Memberships', () => {
+      it('does not show the question if the role is a legal role', () => {
+        wrapper.setData({ typeOfExercise: 'legal' });
+        expect(wrapper.find('#memberships').exists()).toBe(false);
+      });
+
+      it('does not show the question if the role is a senior role', () => {
+        wrapper.setData({ typeOfExercise: 'senior' });
+        expect(wrapper.find('#memberships').exists()).toBe(false);
+      });
+
+      it('does not show the question if the role is a leadership role', () => {
         wrapper.setData({ typeOfExercise: 'leadership' });
-        expect(wrapper.find('#post-qualification-experience').exists()).toBe(true);
+        expect(wrapper.find('#memberships').exists()).toBe(false);
+      });
+
+      it('does show the question if the role is a non-legal role', () => {
+        wrapper.setData({ typeOfExercise: 'non-legal' });
+        expect(wrapper.find('#memberships').exists()).toBe(true);
       });
     });
   });


### PR DESCRIPTION
This PR contains all amendments to the eligibility page. This work equates to multiple tickets. 

Things that have been completed:
- The Qualifications question will only render if the typeOfExercise is _not_ non-legal.
- The Memberships question will only render if the typeOfExercise _is_ non-legal or leadership


Tests for all these tasks have been written up, and are passing. The code has been linted too. 