### PR TITLE
Fixup

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -28,7 +28,7 @@ import ExerciseShowIndependentAssessments from '@/views/Exercises/Show/Independe
 import ExerciseReports from '@/views/Exercises/Reports';
 import ExerciseReportsCharacterIssues from '@/views/Exercises/Reports/CharacterIssues';
 import ExerciseReportsCharacterChecks from '@/views/Exercises/Reports/CharacterChecks';
-import ExerciseReportsDiversityReport from '@/views/Exercises/Reports/DiversityReport';
+import ExerciseReportsDiversityDashboard from '@/views/Exercises/Reports/DiversityDashboard';
 import ExerciseReportsEligibilityIssues from '@/views/Exercises/Reports/EligibilityIssues';
 import ExerciseReportsEducationAndCareerHistory from '@/views/Exercises/Reports/EducationAndCareerHistory';
 import ExerciseReportsJOHandoverReport from '@/views/Exercises/Reports/JOHandoverReport';
@@ -258,12 +258,12 @@ const router = new Router({
           },
         },
         {
-          path: 'diversity-report',
-          component: ExerciseReportsDiversityReport,
-          name: 'exercise-reports-diversity-report',
+          path: 'diversity-dashboard',
+          component: ExerciseReportsDiversityDashboard,
+          name: 'exercise-reports-diversity-dashboard',
           meta: {
             requiresAuth: true,
-            title: 'Diversity Report',
+            title: 'Diversity Dashboard',
           },
         },
         {

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -186,10 +186,8 @@ export default {
         scenarioTestStartTime: exercise.scenarioTestStartTime || null,
         scenarioTestEndTime: exercise.scenarioTestEndTime || null,
         contactIndependentAssessors: exercise.contactIndependentAssessors || null,
-        selectionDayStart: exercise.selectionDayStart || null,
-        selectionDayEnd: exercise.selectionDayEnd || null,
         finalOutcome: exercise.finalOutcome || null,
-        selectionDays: exercise.selectionDays || [],
+        selectionDays: exercise.selectionDays || null,
       },
     };
   },

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -72,6 +72,7 @@
               <select
                 id="salary-group"
                 class="govuk-select"
+                v-model="exercise.salaryGrouping"
               >
                 <option value="">
                   Select an option
@@ -281,9 +282,10 @@ export default {
 
     return {
       exercise: {
-        typeOfExercise: exercise.typeOfExercise || [],
-        isCourtOrTribunal: exercise.isCourtOrTribunal || [],
-        appointmentType: exercise.appointmentType || [],
+        typeOfExercise: exercise.typeOfExercise || null,
+        isCourtOrTribunal: exercise.isCourtOrTribunal || null,
+        appointmentType: exercise.appointmentType || null,
+        salaryGrouping: exercise.salaryGrouping || null,
         feePaidFee: exercise.feePaidFee || null,
         isSPTWOffered: booleanOrNull(exercise.isSPTWOffered),
         yesSalaryDetails: exercise.yesSalaryDetails || null,
@@ -292,7 +294,7 @@ export default {
         futureStart: exercise.futureStart || null,
         location: exercise.location || null,
         jurisdiction: exercise.jurisdiction || null,
-        welshRequirement: exercise.welshRequirement || [],
+        welshRequirement: exercise.welshRequirement || null,
         aboutTheRole: exercise.aboutTheRole || null,
 
       },

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -71,43 +71,43 @@
               </label>
               <select
                 id="salary-group"
-                class="govuk-select"
                 v-model="exercise.salaryGrouping"
+                class="govuk-select"
               >
                 <option value="">
                   Select an option
                 </option>
-                <option value="group1">
+                <option value="Group 1">
                   Group 1 - £262,264
                 </option>
-                <option value="group1.1">
+                <option value="Group 1.1">
                   Group 1.1 - £234,184
                 </option>
-                <option value="group2">
+                <option value="Group ">
                   Group 2 - £226,193
                 </option>
-                <option value="group3">
+                <option value="Group 3">
                   Group 3 - £215,094
                 </option>
-                <option value="group4">
+                <option value="Group 4">
                   Group 4 - £188,901
                 </option>
-                <option value="group5+">
+                <option value="Group 5+">
                   Group 5+ - £160,377
                 </option>
-                <option value="group5">
+                <option value="Group 5">
                   Group 5 - £151,497
                 </option>
-                <option value="group6.1">
+                <option value="Group 6.1">
                   Group 6.1 - £140,289
                 </option>
-                <option value="group6.2">
+                <option value="Group 6.2">
                   Group 6.2 - £132,075
                 </option>
-                <option value="group7">
+                <option value="Group 7">
                   Group 7 - £112,542
                 </option>
-                <option value="group8">
+                <option value="Group 8">
                   Group 8 - £89,428
                 </option>
               </select>

--- a/src/views/Exercises/New.vue
+++ b/src/views/Exercises/New.vue
@@ -92,7 +92,7 @@ export default {
     return {
       exerciseName: null,
       addMoreInfo: null,
-      addMoreInfoSelection: [],
+      addMoreInfoSelection: null,
     };
   },
   methods: {

--- a/src/views/Exercises/Show/Reports.vue
+++ b/src/views/Exercises/Show/Reports.vue
@@ -26,7 +26,7 @@
       <li class="govuk-!-margin-bottom-4">
         <router-link
           class="govuk-link govuk-body-l"
-          :to="{name: 'exercise-reports-diversity-report'}"
+          :to="{name: 'exercise-reports-diversity-dashboard'}"
         >
           Diversity report
         </router-link>

--- a/src/views/Exercises/Show/Vacancy.vue
+++ b/src/views/Exercises/Show/Vacancy.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="text-right">
-      <router-link 
+      <router-link
         class="govuk-link"
         :to="{name: 'exercise-edit-vacancy'}"
       >
@@ -43,7 +43,7 @@
           Salary group
         </dt>
         <dd class="govuk-summary-list__value">
-          {{ exercise.feePaidFee }}
+          {{ exercise.salaryGrouping }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -23,7 +23,7 @@ const routes = [
   ['page-not-found', 'Page Not Found'],
   ['exercise-reports-character-checks', 'Character Checks'],
   ['exercise-reports-character-issues', 'Character Issues'],
-  ['exercise-reports-diversity-report', 'Diversity Report'],
+  ['exercise-reports-diversity-dashboard', 'Diversity Dashboard'],
   ['exercise-reports-eligibility-issues', 'Eligibility Issues'],
   ['exercise-reports-education-and-career-history', 'Education and Career History'],
   ['exercise-reports-jo-handover-report', 'JO Handover Report'],

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -22,7 +22,7 @@ const routes = [
   ['exercise-edit-name', `/exercises/${id}/edit/name`],
   ['exercise-reports-character-issues', `/exercises/${id}/report-directory/character-issues`],
   ['exercise-reports-character-checks', `/exercises/${id}/report-directory/character-checks`],
-  ['exercise-reports-diversity-report', `/exercises/${id}/report-directory/diversity-report`],
+  ['exercise-reports-diversity-dashboard', `/exercises/${id}/report-directory/diversity-dashboard`],
   ['exercise-reports-eligibility-issues', `/exercises/${id}/report-directory/eligibility-issues`],
   ['exercise-reports-education-and-career-history', `/exercises/${id}/report-directory/education-and-career-history`],
   ['exercise-reports-jo-handover-report', `/exercises/${id}/report-directory/jo-handover-report`],


### PR DESCRIPTION
This is just a branch to fix up some of the little things that might have been lost amongst the merges and rebasing. 

Things done: 
- Amended the Diversity Dashboard errors. I've mixed up Diversity report and Diversity dashboard across branches. It's all Diversity Dashboard now, but the link to the report still says Diversity Report.

- Amended some things on the Vacancy page. I hadn't saved and pushed the salary grouping choice. This now saves that data to firebase. I also amended any stray empty arrays from the data area. We used to have to set the checkboxes to equal empty arrays or something from the DB but we amended that bug and those variables just hadn't been amended. I also amended the values of the salary group to be more user friendly, so that it was in proper english format when regurgitated on the show page. 

- amended the Timeline page. It had one of those empty arrays and it also had 2 variables that were redundant. This was the selection day start, and the selection day end. Selection day is a repeatable field, so that covers the variables in there. These extra variables weren't doing anything. 

- Amended the New page. It had an empty array. 