### PR TITLE
Amended the Vacancy Show page to not list about the role twice

### DIFF
--- a/src/views/Exercises/Show/Vacancy.vue
+++ b/src/views/Exercises/Show/Vacancy.vue
@@ -116,14 +116,6 @@
           </ul>
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          About the role
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ exercise.aboutTheRole }}
-        </dd>
-      </div>
     </dl>
   </div>
 </template>


### PR DESCRIPTION
Removed the extra 'About the role' rendering on the Vacancy show page. 

Linted and tests are passing