### PR TITLE
Timeline Additions

### DIFF
--- a/src/helpers/Timeline/exerciseTimeline.js
+++ b/src/helpers/Timeline/exerciseTimeline.js
@@ -39,51 +39,78 @@ const createSelectionDay = (data) => {
 const exerciseTimeline = (data) => {
   return [
   {
-    entry: 'Open for applications', 
+    entry: 'Open for applications',
     date: isDate(data.applicationOpenDate) ? formatDate(data.applicationOpenDate) : null,
   },
   {
-    entry: 'Closed for applications', 
+    entry: 'Closed for applications',
     date: isDate(data.applicationCloseDate) ? formatDate(data.applicationCloseDate) : null,
   },
   {
-    entry: 'QT', 
+    entry: 'Shortlisting',
+  },
+  {
+    entry: 'Sift date',
+    date: isDate(data.siftDate) ? formatDate(data.siftDate) : null,
+  },
+  {
+    entry: 'Name-blind sift date',
+    date: isDate(data.nameBlindSiftDate) ? formatDate(data.nameBlindSiftDate) : null,
+  },
+  {
+    entry: 'Telephone assessment date',
+    date: isDate(data.telephoneAssessmentDate) ? formatDate(data.telephoneAssessmentDate) : null,
+  },
+  {
+    entry: 'Shortlisting outcome date',
+    date: isDate(data.shortlistingOutcomeDate) ? formatDate(data.shortlistingOutcomeDate) : null,
+  },
+  {
+    entry: 'QT',
     date: createQT(data),
   },
   {
-    entry: 'Paper sift', 
-    date: isDate(data.paperSiftDate) ? formatDate(data.paperSiftDate) : null,
-  },
-  {
-    entry: 'QT outcome to candidates', 
+    entry: 'QT outcome to candidates',
     date: isDate(data.sjcaTestOutcome) ? formatDate(data.sjcaTestOutcome, 'month') : null,
   },
   {
-    entry: 'Scenario test', 
+    entry: 'Scenario test',
     date: createScenariotest(data),
   },
   {
-    entry: 'Scenario test outcome to candidates', 
+    entry: 'Scenario test outcome to candidates',
     date: isDate(data.scenarioTestOutcome) ? formatDate(data.scenarioTestOutcome) : null,
   },
   {
-    entry: 'Contact independent assessors', 
+    entry: 'Contact independent assessors',
     date: isDate(data.contactIndependentAssessors) ? formatDate(data.contactIndependentAssessors) : null,
   },
   {
-    entry: 'Selection day', 
+    entry: 'Return date for independent assessments',
+    date: isDate(data.independentAssessmentsReturnDate) ? formatDate(data.independentAssessmentsReturnDate) : null,
+  },
+  {
+    entry: 'Eligibility SCC',
+    date: isDate(data.eligibilitySCCDate) ? formatDate(data.eligibilitySCCDate) : null,
+  },
+  {
+    entry: 'Selection day',
     date: createSelectionDay(data),
   },
   {
-    entry: 'Character checks', 
-    date: isDate(data.characterChecks) ? formatDate(data.characterChecks, 'month') : null,
+    entry: 'Character checks',
+    date: isDate(data.characterChecksDate) ? formatDate(data.characterChecksDate) : null,
   },
   {
-    entry: 'Statutory consultation', 
-    date: isDate(data.statutoryConsultation) ? formatDate(data.statutoryConsultation, 'month') : null,
+    entry: 'Statutory consultation',
+    date: isDate(data.statutoryConsultationDate) ? formatDate(data.statutoryConsultationDate) : null,
   },
   {
-    entry: 'Selection process outcome', 
+    entry: 'Character and Selection SCC',
+    date: isDate(data.characterAndSCCDate) ? formatDate(data.characterAndSCCDate) : null,
+  },
+  {
+    entry: 'Selection process outcome',
     date: isDate(data.finalOutcome) ? formatDate(data.finalOutcome, 'month') : null,
   }];
 };

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -6,10 +6,10 @@
         <h1 class="govuk-heading-xl">
           Timeline
         </h1>
-        <ErrorSummary 
-          :errors="errors" 
-          :show-save-button="true" 
-          @save="save" 
+        <ErrorSummary
+          :errors="errors"
+          :show-save-button="true"
+          @save="save"
         />
         <p class="govuk-body-l">
           You can return to this page later to add or change dates.
@@ -44,7 +44,7 @@
         />
 
         <h2 class="govuk-heading-l">
-          Shortlisting dates
+          Shortlisting
         </h2>
 
         <div
@@ -52,12 +52,24 @@
           ref="paperSift"
         >
           <h3 class="govuk-heading-m">
-            Paper sift
+            Sifts
           </h3>
           <DateInput
-            id="paper-sift"
-            v-model="exercise.paperSiftDate"
+            id="sift-date"
+            v-model="exercise.siftDate"
             label="Sift date"
+            required
+          />
+          <DateInput
+            id="name-blind-sift-date"
+            v-model="exercise.nameBlindSiftDate"
+            label="Name-blind sift date"
+            required
+          />
+          <DateInput
+            id="telephone-assessment-date"
+            v-model="exercise.telephoneAssessmentDate"
+            label="Telephone assessment date"
             required
           />
         </div>
@@ -128,6 +140,12 @@
             required
           />
         </div>
+        <DateInput
+          id="shortlisting-outcome-date"
+          v-model="exercise.shortlistingOutcomeDate"
+          label="Shortlisting outcome date"
+          required
+        />
 
         <h2 class="govuk-heading-l">
           Independent assessors
@@ -140,6 +158,23 @@
           hint="Email reminders will be sent to assessors who have not responded after 2 weeks."
           required
         />
+        <DateInput
+          id="independent-assessments-return-date"
+          v-model="exercise.independentAssessmentsReturnDate"
+          label="Independent assessments return date"
+          required
+        />
+
+        <h2 class="govuk-heading-l">
+          Eligibility SCC
+        </h2>
+
+        <DateInput
+          id="eligibility-scc-date"
+          v-model="exercise.eligibilitySCCDate"
+          label="Eligibility SCC date"
+          required
+        />
 
         <h2 class="govuk-heading-l">
           Selection day
@@ -148,6 +183,39 @@
         <RepeatableFields
           v-model="exercise.selectionDays"
           :component="repeatableFields.SelectionDay"
+          required
+        />
+
+        <h2 class="govuk-heading-l">
+          Character Checks
+        </h2>
+
+        <DateInput
+          id="character-checks-date"
+          v-model="exercise.characterChecksDate"
+          label="Character checks date"
+          required
+        />
+
+        <h2 class="govuk-heading-l">
+          Statutory Consultation
+        </h2>
+
+        <DateInput
+          id="statutory-consultation-date"
+          v-model="exercise.statutoryConsultationDate"
+          label="Statutory Consultation date"
+          required
+        />
+
+        <h2 class="govuk-heading-l">
+          Character and Selection SCC
+        </h2>
+
+        <DateInput
+          id="character-and-selection-scc-date"
+          v-model="exercise.characterAndSCCDate"
+          label="Final outcome to candidates"
           required
         />
 
@@ -200,7 +268,9 @@ export default {
       exercise: {
         applicationOpenDate: exercise.applicationOpenDate || null,
         applicationCloseDate: exercise.applicationCloseDate || null,
-        paperSiftDate: exercise.paperSiftDate || null,
+        siftDate: exercise.siftDate || null,
+        nameBlindSiftDate: exercise.nameBlindSiftDate || null,
+        telephoneAssessmentDate: exercise.telephoneAssessmentDate || null,
         sjcaTestDate: exercise.sjcaTestDate || null,
         sjcaTestStartTime: exercise.sjcaTestStartTime || null,
         sjcaTestEndTime: exercise.sjcaTestEndTime || null,
@@ -209,21 +279,27 @@ export default {
         scenarioTestStartTime: exercise.scenarioTestStartTime || null,
         scenarioTestEndTime: exercise.scenarioTestEndTime || null,
         scenarioTestOutcome: exercise.scenarioTestOutcome || null,
+        shortlistingOutcomeDate: exercise.shortlistingOutcomeDate || null,
         contactIndependentAssessors: exercise.contactIndependentAssessors || null,
-        finalOutcome: exercise.finalOutcome || null,
+        independentAssessmentsReturnDate: exercise.independentAssessmentsReturnDate || null,
+        eligibilitySCCDate: exercise.eligibilitySCCDate || null,
         selectionDays: exercise.selectionDays || null,
+        characterChecksDate: exercise.characterChecksDate || null,
+        statutoryConsultationDate: exercise.statutoryConsultationDate || null,
+        characterAndSCCDate: exercise.characterAndSCCDate || null,
+        finalOutcome: exercise.finalOutcome || null,
       },
     };
   },
   computed: {
     scenarioQT() {
-      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('Scenario test qualifying test (QT)');
+      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('scenario-test-qualifying-test');
     },
     situationalJudgementOrCriticalAnalysisQT() {
-      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('Situational judgement qualifying test (QT)') || this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('Critical analysis qualifying test (QT)');
+      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('situational-judgement-qualifying-test') || this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('critical-analysis-qualifying-test');
     },
     paperSift() {
-      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('Paper sift');
+      return this.exerciseShortlistingMethods && this.exerciseShortlistingMethods.includes('paper-sift');
     },
   },
   methods: {

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -215,7 +215,7 @@
         <DateInput
           id="character-and-selection-scc-date"
           v-model="exercise.characterAndSCCDate"
-          label="Final outcome to candidates"
+          label="Character and SCC date"
           required
         />
 


### PR DESCRIPTION
* I think this spans multiple tickets maybe? not sure 😬 *

- Added some more date fields to the Edit/Timeline page - collects some additional data we were missing. Ticket didn't specify what type of date, so I've left it as a full date but this can easily be changed to a month only date if needs be so keep ya eyes peeled for that. 

- Added this new and shiny collected data to the Show/Timeline page. It doesn't exactly match the wireframe given, because the wireframe excludes the preexisting data about QT's and Scenario tests. I can remove this if needed to however Warren and I felt it was worth leaving in for now until we get clarity. 

- What needs to be done: 
This PR doesn't include the whole candidate/admin timeline split thing. This PR just shows all the required fields to the Admins. I'm not sure what's shown to the candidates on the other side yet but that'll be addressed in a separate PR or added on to this one.

🐝 