### PR TITLE
Added styling to the download links

### DIFF
--- a/src/components/DownloadLink.vue
+++ b/src/components/DownloadLink.vue
@@ -1,0 +1,82 @@
+<template>
+  <a
+    class="govuk-link"
+    :class="{'download-visited' : visited }"
+    href="javascript:void(0)"
+    @click.prevent="download(fileName)"
+  >
+    {{ fileName }}
+  </a>
+</template>
+
+<script>
+import firebase from 'firebase';
+export default {
+  props: {
+    fileName: {
+      required: true,
+      type: String,
+      default: null,
+    },
+    exerciseId: {
+      required: true,
+      type: String,
+      default: null,
+    },
+  },
+  data () {
+    return {
+      visited: false,
+    };
+  },
+  methods: {
+    download(fileName) {
+      this.visited = true;
+      // Create a reference to the file we want to download
+      const fileSavePath = `exercise-${this.exerciseId}/${fileName}`;
+
+      // Get a reference to the storage service, which is used to create references in your storage bucket
+      const storage = firebase.storage();
+
+      // Create a storage reference from our storage service
+      const storageRef = storage.ref();
+
+      // Create a reference with an initial file path and name
+      const fileNameRef = storageRef.child(fileSavePath);
+
+      // Get the download URL
+      fileNameRef.getDownloadURL().then((url) => {
+        // open url in another window
+        window.open(url);
+      }).catch((error) => {
+
+        // A full list of error codes is available at
+        // https://firebase.google.com/docs/storage/web/handle-errors
+        switch (error.code) {
+        case 'storage/object-not-found':
+          // File doesn't exist
+          break;
+
+        case 'storage/unauthorized':
+          // User doesn't have permission to access the object
+          break;
+
+        case 'storage/canceled':
+          // User canceled the upload
+          break;
+
+        case 'storage/unknown':
+          // Unknown error occurred, inspect the server response
+          break;
+        }
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.download-visited {
+  color: #4c2c92;
+}
+</style>

--- a/src/views/Exercises/Show/Downloads.vue
+++ b/src/views/Exercises/Show/Downloads.vue
@@ -21,8 +21,9 @@
           <a
             id="job-description-template"
             class="govuk-link"
+            :class="{'download-visited': documentsDownloaded.jobDescription}"
             href="javascript:void(0)"
-            @click.prevent="download(exercise.uploadedJobDescriptionTemplate); lookVisited('job-description-template')"
+            @click.prevent="download(exercise.uploadedJobDescriptionTemplate); documentsDownloaded.jobDescription = true; "
           >
             {{ exercise.uploadedJobDescriptionTemplate }}</a>
         </dd>
@@ -35,8 +36,9 @@
           <a
             id="terms-and-conditions-template"
             class="govuk-link"
+            :class="{'download-visited': documentsDownloaded.termsAndConditions}"
             href="javascript:void(0)"
-            @click.prevent="download(exercise.uploadedTermsAndConditionsTemplate); lookVisited('terms-and-conditions-template')"
+            @click.prevent="download(exercise.uploadedTermsAndConditionsTemplate); documentsDownloaded.jobDescription = true;"
           >{{ exercise.uploadedTermsAndConditionsTemplate }}</a>
         </dd>
       </div>
@@ -48,8 +50,9 @@
           <a
             id="independent-assessor-template"
             class="govuk-link"
+            :class="{'download-visited': documentsDownloaded.independentAssessor}"
             href="javascript:void(0)"
-            @click="download(exercise.uploadedIndependentAssessorTemplate); lookVisited('independent-assessor-template')"
+            @click="download(exercise.uploadedIndependentAssessorTemplate); documentsDownloaded.independentAssessor = true;"
           >{{ exercise.uploadedIndependentAssessorTemplate }}</a>
         </dd>
       </div>
@@ -61,8 +64,9 @@
           <a
             id="candidate-assessment-form-template"
             class="govuk-link"
+            :class="{'download-visited': documentsDownloaded.candidateAssessmentForm}"
             href="javascript:void(0)"
-            @click="download(exercise.uploadedCandidateAssessmentFormTemplate); lookVisited('candidate-assessment-form-template')"
+            @click="download(exercise.uploadedCandidateAssessmentFormTemplate); documentsDownloaded.independentAssessor = true; "
           >{{ exercise.uploadedCandidateAssessmentFormTemplate }}</a>
         </dd>
       </div>
@@ -74,6 +78,16 @@
 import firebase from 'firebase';
 
 export default {
+  data () {
+    return {
+      documentsDownloaded: {
+        jobDescription: false,
+        termsAndConditions: false,
+        independentAssessor: false,
+        candidateAssessmentForm: false,
+      },
+    };
+  },
   computed: {
     exercise() {
       return this.$store.getters['exerciseDocument/data']();
@@ -136,7 +150,7 @@ export default {
 
 <style scoped>
 
-.download-visted {
+.download-visited {
   color: #4c2c92;
 }
 

--- a/src/views/Exercises/Show/Downloads.vue
+++ b/src/views/Exercises/Show/Downloads.vue
@@ -18,14 +18,10 @@
           Job Description Template
         </dt>
         <dd class="govuk-summary-list__value">
-          <a
-            id="job-description-template"
-            class="govuk-link"
-            :class="{'download-visited': documentsDownloaded.jobDescription}"
-            href="javascript:void(0)"
-            @click.prevent="download(exercise.uploadedJobDescriptionTemplate); documentsDownloaded.jobDescription = true; "
-          >
-            {{ exercise.uploadedJobDescriptionTemplate }}</a>
+          <DownloadLink
+            :file-name="exercise.uploadedJobDescriptionTemplate"
+            :exercise-id="exerciseId"
+          />
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -33,13 +29,10 @@
           Terms and Conditions Template
         </dt>
         <dd class="govuk-summary-list__value">
-          <a
-            id="terms-and-conditions-template"
-            class="govuk-link"
-            :class="{'download-visited': documentsDownloaded.termsAndConditions}"
-            href="javascript:void(0)"
-            @click.prevent="download(exercise.uploadedTermsAndConditionsTemplate); documentsDownloaded.jobDescription = true;"
-          >{{ exercise.uploadedTermsAndConditionsTemplate }}</a>
+          <DownloadLink
+            :file-name="exercise.uploadedTermsAndConditionsTemplate"
+            :exercise-id="exerciseId"
+          />
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -47,13 +40,10 @@
           Independent Assessor Template
         </dt>
         <dd class="govuk-summary-list__value">
-          <a
-            id="independent-assessor-template"
-            class="govuk-link"
-            :class="{'download-visited': documentsDownloaded.independentAssessor}"
-            href="javascript:void(0)"
-            @click="download(exercise.uploadedIndependentAssessorTemplate); documentsDownloaded.independentAssessor = true;"
-          >{{ exercise.uploadedIndependentAssessorTemplate }}</a>
+          <DownloadLink
+            :file-name="exercise.uploadedIndependentAssessorTemplate"
+            :exercise-id="exerciseId"
+          />
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -61,13 +51,10 @@
           Candidate Assessment Form Template
         </dt>
         <dd class="govuk-summary-list__value">
-          <a
-            id="candidate-assessment-form-template"
-            class="govuk-link"
-            :class="{'download-visited': documentsDownloaded.candidateAssessmentForm}"
-            href="javascript:void(0)"
-            @click="download(exercise.uploadedCandidateAssessmentFormTemplate); documentsDownloaded.independentAssessor = true; "
-          >{{ exercise.uploadedCandidateAssessmentFormTemplate }}</a>
+          <DownloadLink
+            :file-name="exercise.uploadedCandidateAssessmentFormTemplate"
+            :exercise-id="exerciseId"
+          />
         </dd>
       </div>
     </dl>
@@ -75,18 +62,11 @@
 </template>
 
 <script>
-import firebase from 'firebase';
+import DownloadLink from '@/components/DownloadLink';
 
 export default {
-  data () {
-    return {
-      documentsDownloaded: {
-        jobDescription: false,
-        termsAndConditions: false,
-        independentAssessor: false,
-        candidateAssessmentForm: false,
-      },
-    };
+  components: {
+    DownloadLink,
   },
   computed: {
     exercise() {
@@ -99,59 +79,9 @@ export default {
       return this.$store.getters['exerciseDocument/id'];
     },
   },
-  methods: {
-    download(fileName) {
-      // Create a reference to the file we want to download
-      const fileSavePath = `exercise-${this.exerciseId}/${fileName}`;
-
-      // Get a reference to the storage service, which is used to create references in your storage bucket
-      const storage = firebase.storage();
-
-      // Create a storage reference from our storage service
-      const storageRef = storage.ref();
-
-      // Create a reference with an initial file path and name
-      const fileNameRef = storageRef.child(fileSavePath);
-
-      // Get the download URL
-      fileNameRef.getDownloadURL().then((url) => {
-        // open url in another window
-        window.open(url);
-      }).catch((error) => {
-
-        // A full list of error codes is available at
-        // https://firebase.google.com/docs/storage/web/handle-errors
-        switch (error.code) {
-        case 'storage/object-not-found':
-          // File doesn't exist
-          break;
-
-        case 'storage/unauthorized':
-          // User doesn't have permission to access the object
-          break;
-
-        case 'storage/canceled':
-          // User canceled the upload
-          break;
-
-        case 'storage/unknown':
-          // Unknown error occurred, inspect the server response
-          break;
-        }
-      });
-    },
-    lookVisited(id) {
-      var download = document.getElementById(id);
-      download.classList.toggle('download-visted');
-    },
-  },
 };
 </script>
 
 <style scoped>
-
-.download-visited {
-  color: #4c2c92;
-}
 
 </style>

--- a/src/views/Exercises/Show/Downloads.vue
+++ b/src/views/Exercises/Show/Downloads.vue
@@ -19,12 +19,12 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <a
-            style="
-              color: blue;
-              text-decoration: underline;
-          "
-            @click="download(exercise.uploadedJobDescriptionTemplate)"
-          >{{ exercise.uploadedJobDescriptionTemplate }}</a>
+            id="job-description-template"
+            class="govuk-link"
+            href="javascript:void(0)"
+            @click.prevent="download(exercise.uploadedJobDescriptionTemplate); lookVisited('job-description-template')"
+          >
+            {{ exercise.uploadedJobDescriptionTemplate }}</a>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -33,11 +33,10 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <a
-            style="
-              color: blue;
-              text-decoration: underline;
-          "
-            @click="download(exercise.uploadedTermsAndConditionsTemplate)"
+            id="terms-and-conditions-template"
+            class="govuk-link"
+            href="javascript:void(0)"
+            @click.prevent="download(exercise.uploadedTermsAndConditionsTemplate); lookVisited('terms-and-conditions-template')"
           >{{ exercise.uploadedTermsAndConditionsTemplate }}</a>
         </dd>
       </div>
@@ -47,11 +46,10 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <a
-            style="
-              color: blue;
-              text-decoration: underline;
-          "
-            @click="download(exercise.uploadedIndependentAssessorTemplate)"
+            id="independent-assessor-template"
+            class="govuk-link"
+            href="javascript:void(0)"
+            @click="download(exercise.uploadedIndependentAssessorTemplate); lookVisited('independent-assessor-template')"
           >{{ exercise.uploadedIndependentAssessorTemplate }}</a>
         </dd>
       </div>
@@ -61,14 +59,13 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <a
-            style="
-              color: blue;
-              text-decoration: underline;
-          "
-            @click="download(exercise.uploadedCandidateAssessmentFormTemplate)"
+            id="candidate-assessment-form-template"
+            class="govuk-link"
+            href="javascript:void(0)"
+            @click="download(exercise.uploadedCandidateAssessmentFormTemplate); lookVisited('candidate-assessment-form-template')"
           >{{ exercise.uploadedCandidateAssessmentFormTemplate }}</a>
         </dd>
-      </div>                       
+      </div>
     </dl>
   </div>
 </template>
@@ -129,6 +126,18 @@ export default {
         }
       });
     },
+    lookVisited(id) {
+      var download = document.getElementById(id);
+      download.classList.toggle('download-visted');
+    },
   },
 };
 </script>
+
+<style scoped>
+
+.download-visted {
+  color: #4c2c92;
+}
+
+</style>


### PR DESCRIPTION
I tried to use the standard govuk-link styling to get the download links to look like the gov ones, however that style required a href. When you gave it a href, it just redirected to it and didn't conduct the download which was dumb. I tried using fancy CSS styles but they were hard to implement the whole 'visited state' thing.

My (and Warren's) solution was to add in the href using ```href="javascript:void(0)"``` to make the govuk-link style happy but remove any unwanted side effects of the href. This however didn't make the download links that cute purple once clicked. Now we have a data object that has keys for each document, and an initial value of false. Once the @click triggers the data object to change that document's value to true, an object bound to the class will apply a new styling. 
