### PR TITLE
Add another option required for "Lead Judge" on Contacts

### DIFF
--- a/src/components/RepeatableFields/LeadJudge.vue
+++ b/src/components/RepeatableFields/LeadJudge.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <TextField
+      :id="`lead_judge_${index}`"
+      v-model="row.name"
+      type="email"
+      label="Lead judge"
+      required
+    />
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import TextField from '@/components/Form/TextField';
+
+export default {
+  components: {
+    TextField,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+  },
+};
+</script>

--- a/src/views/Exercises/Edit/Contacts.vue
+++ b/src/views/Exercises/Edit/Contacts.vue
@@ -121,12 +121,9 @@
           type="email"
         />
 
-        <TextField
-          id="lead-judge"
+        <RepeatableFields
           v-model="exercise.leadJudge"
-          name="lead-judge"
-          label="Lead judge"
-          type="email"
+          :component="repeatableFields.LeadJudge"
           required
         />
 
@@ -160,6 +157,7 @@ import RepeatableFields from '@/components/RepeatableFields';
 import SeniorSelectionExerciseManager from '@/components/RepeatableFields/SeniorSelectionExerciseManager';
 import SelectionExerciseManager from '@/components/RepeatableFields/SelectionExerciseManager';
 import DraftingJudge from '@/components/RepeatableFields/DraftingJudge';
+import LeadJudge from '@/components/RepeatableFields/LeadJudge';
 import StatutoryConsultee from '@/components/RepeatableFields/StatutoryConsultee';
 import SelectionExerciseOfficer from '@/components/RepeatableFields/SelectionExerciseOfficer';
 import AssignedCommissioner from '@/components/RepeatableFields/AssignedCommissioner';
@@ -201,6 +199,7 @@ export default {
         SeniorSelectionExerciseManager,
         SelectionExerciseManager,
         DraftingJudge,
+        LeadJudge,
         StatutoryConsultee,
         SelectionExerciseOfficer,
         AssignedCommissioner,

--- a/src/views/Exercises/Show/Contacts.vue
+++ b/src/views/Exercises/Show/Contacts.vue
@@ -123,7 +123,14 @@
           Lead judge
         </dt>
         <dd class="govuk-summary-list__value">
-          {{ exercise.leadJudge }}
+          <ul class="govuk-list">
+            <li
+              v-for="item in exercise.leadJudge"
+              :key="item.name"
+            >
+              {{ item.name }}
+            </li>
+          </ul>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -180,7 +187,7 @@ export default {
     },
     canEdit() {
       return !this.isApproved;
-    },    
+    },
   },
 };
 </script>


### PR DESCRIPTION
Please can we add an "add another" button after the "Lead Judge" field on the Contacts page.  