### PR TITLE
ADMIN:  Add Question to "Vacancy Information" about Statutory Consultation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,20 +44,23 @@
                   <li class="app-c-topic-list__item">
                     <a
                       class="govuk-link app-c-topic-list__link app-c-topic-list__link--no-underline brand__color"
-                      href="https://www.judicialappointments.gov.uk/business-plan" target="_blank"
+                      href="https://www.judicialappointments.gov.uk/business-plan"
+                      target="_blank"
                     >How do I apply</a>
                   </li>
                   <li class="app-c-topic-list__item">
                     <a
                       class="govuk-link app-c-topic-list__link app-c-topic-list__link--no-underline brand__color"
-                      href="https://www.judicialappointments.gov.uk/jac-official-statistics" target="_blank"
+                      href="https://www.judicialappointments.gov.uk/jac-official-statistics"
+                      target="_blank"
                     >How do I qualify</a>
                   </li>
 
                   <li class="app-c-topic-list__item">
                     <a
                       class="govuk-link app-c-topic-list__link app-c-topic-list__link--no-underline brand__color"
-                      href="https://apply.judicialappointments.digital/vacancies" target="_blank"
+                      href="https://apply.judicialappointments.digital/vacancies"
+                      target="_blank"
                     >Judicial vacancies</a>
                   </li>
                   <li class="app-c-topic-list__item">

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -167,6 +167,27 @@
         </CheckboxGroup>
 
         <RadioGroup
+          id="is-statutory-consultation-waived"
+          v-model="exercise.statutoryConsultationWaived"
+          label="Is statutory consultation waived for this exercise?"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          >
+            <TextareaInput
+              id="statutory-consultation-waived-details"
+              v-model="exercise.statutoryConsultationWaivedDetails"
+              label="Explain why."
+            />
+          </RadioItem>
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
           id="appointment-type"
           v-model="exercise.appointmentType"
           label="Appointment type"
@@ -402,6 +423,8 @@ export default {
       location: null,
       jurisdiction: null,
       otherJurisdiction: null,
+      statutoryConsultationWaived: null,
+      statutoryConsultationWaivedDetails: null,
       welshRequirement: null,
       welshRequirementType: null,
       roleSummary: null,

--- a/src/views/Exercises/Edit/Vacancy.vue
+++ b/src/views/Exercises/Edit/Vacancy.vue
@@ -170,6 +170,7 @@
           id="is-statutory-consultation-waived"
           v-model="exercise.statutoryConsultationWaived"
           label="Is statutory consultation waived for this exercise?"
+          required
         >
           <RadioItem
             :value="true"
@@ -179,6 +180,7 @@
               id="statutory-consultation-waived-details"
               v-model="exercise.statutoryConsultationWaivedDetails"
               label="Explain why."
+              required
             />
           </RadioItem>
           <RadioItem

--- a/src/views/Exercises/Show/Vacancy.vue
+++ b/src/views/Exercises/Show/Vacancy.vue
@@ -37,7 +37,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
-            <li 
+            <li
               v-for="item in exercise.jurisdiction"
               :key="item"
             >
@@ -49,6 +49,21 @@
               </span>
             </li>
           </ul>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Waived statutory consultation?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <span
+            v-if="exercise.statutoryConsultationWaivedDetails && exercise.statutoryConsultationWaived == true"
+          >
+            Yes: {{ exercise.statutoryConsultationWaivedDetails }}
+          </span>
+          <span v-else>
+            No
+          </span>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -115,7 +130,7 @@
           </ul>
           <span v-else-if="exercise.welshRequirement === false">None</span>
         </dd>
-      </div>   
+      </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Role summary
@@ -123,15 +138,15 @@
         <dd class="govuk-summary-list__value">
           {{ exercise.roleSummary }}
         </dd>
-      </div>         
+      </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           About the role
         </dt>
         <dd class="govuk-summary-list__value">
           <!-- eslint-disable -->
-          <div 
-            class="govuk-body" 
+          <div
+            class="govuk-body"
             v-html="exercise.aboutTheRole"
           />
           <!-- eslint-enable -->


### PR DESCRIPTION
Please add this question between "Jurisdiction" fields and "Appointment type"

Is statutory consultation waived for this exercise?
Yes or No.

If Yes add text area with a title: "Explain why". 

- I've added this question to both edit and show pages, and I've added the new variables to the data sheet. Were you planning on adding yes or no to the look ups? I've left them out as other variables on the show page didn't use lookup for their yes/no rendering, but if you want me to add them in then I can? 