### PR TITLE
Timeline. Add 'EMP Second Interview' date field

### DIFF
--- a/src/helpers/Timeline/exerciseTimeline.js
+++ b/src/helpers/Timeline/exerciseTimeline.js
@@ -219,6 +219,30 @@ const exerciseTimeline = (data) => {
     );
   }
 
+  if (data.equalMeritSecondStageStartDate) {
+    timeline.push(
+      createShortlistingMethod('Equal merit second stage', data.equalMeritSecondStageStartDate, data.equalMeritSecondStageEndDate)
+    );
+  }
+
+  if (data.eMPSCCDate) {
+    timeline.push(
+      {
+        entry: 'EMP SCC',
+        date: isDate(data.eMPSCCDate) ? formatDate(data.eMPSCCDate) : null,
+      }
+    );
+  }
+
+  if (data.eMPOutcomeDate) {
+    timeline.push(
+      {
+        entry: 'EMP Outcomes',
+        date: isDate(data.eMPOutcomeDate) ? formatDate(data.eMPOutcomeDate, 'month') : null,
+      }
+    );
+  }
+
   return timeline;
 };
 

--- a/src/views/Exercises/Edit/Timeline.vue
+++ b/src/views/Exercises/Edit/Timeline.vue
@@ -226,6 +226,34 @@
           type="month"
           required
         />
+        <h2 class="govuk-heading-l">
+          Equal merit dates
+        </h2>
+        <DateInput
+          id="emd-second-stage-start-date"
+          v-model="exercise.equalMeritSecondStageStartDate"
+          label="Second stage start date"
+          required
+        />
+        <DateInput
+          id="emd-second-stage-end-date"
+          v-model="exercise.equalMeritSecondStageEndDate"
+          label="Second stage end date"
+          required
+        />
+        <DateInput
+          id="emp-scc-date"
+          v-model="exercise.eMPSCCDate"
+          label="EMP SCC date"
+          required
+        />
+        <DateInput
+          id="emp-outcome-date"
+          v-model="exercise.eMPOutcomeDate"
+          label="EMP Outcomes"
+          type="month"
+          required
+        />
         <button class="govuk-button">
           Save and continue
         </button>
@@ -277,9 +305,13 @@ export default {
       statutoryConsultationDate: null,
       characterAndSCCDate: null,
       finalOutcome: null,
+      equalMeritSecondStageStartDate: null,
+      equalMeritSecondStageEndDate: null,
+      eMPSCCDate: null,
+      eMPOutcomeDate: null,
     };
     const data = this.$store.getters['exerciseDocument/data']();
-    const exercise = { ...defaults, ...data };    
+    const exercise = { ...defaults, ...data };
     return {
       repeatableFields: {
         SelectionDay,


### PR DESCRIPTION
Admin/staff side
•	On the ‘Timeline’ page there is no option to add a date for an Equal Merit Provision second interview/online tie break test.

Add additional date field for EMP Second Interview
